### PR TITLE
Implement workspace validation middleware

### DIFF
--- a/supchat-server/middlewares/validationMiddleware.js
+++ b/supchat-server/middlewares/validationMiddleware.js
@@ -1,0 +1,30 @@
+const validate = ({ body: bodySchema, params: paramsSchema }) => {
+  return (req, res, next) => {
+    const bodyResult = bodySchema
+      ? bodySchema.validate(req.body, { abortEarly: false })
+      : { value: req.body };
+    const paramsResult = paramsSchema
+      ? paramsSchema.validate(req.params, { abortEarly: false })
+      : { value: req.params };
+
+    if (bodyResult.error || paramsResult.error) {
+      const details = [];
+      if (bodyResult.error) details.push(...bodyResult.error.details);
+      if (paramsResult.error) details.push(...paramsResult.error.details);
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Validation failed",
+          details: details.map((d) => d.message)
+        }
+      });
+    }
+
+    req.body = bodyResult.value;
+    req.params = paramsResult.value;
+    return next();
+  };
+};
+
+module.exports = { validate };

--- a/supchat-server/routes/workspace.Routes.js
+++ b/supchat-server/routes/workspace.Routes.js
@@ -1,35 +1,69 @@
-const express = require('express')
-const workspaceController = require('../controllers/workspaceController')
+const express = require("express");
+const workspaceController = require("../controllers/workspaceController");
+const { authMiddleware, roleMiddleware } = require("../middlewares/authMiddleware");
 const {
-    authMiddleware,
-    roleMiddleware,
-} = require('../middlewares/authMiddleware')
+  createWorkspaceSchema,
+  updateWorkspaceSchema,
+  inviteToWorkspaceSchema,
+  joinWorkspaceSchema,
+  workspaceIdParamSchema
+} = require("../validators/workspaceValidators");
+const { validate } = require("../middlewares/validationMiddleware");
 
-const router = express.Router()
+const router = express.Router();
 
 // Créer un workspace (admin uniquement)
-router.post('/', authMiddleware, workspaceController.createWorkspace)
+router.post(
+  "/",
+  authMiddleware,
+  validate({ body: createWorkspaceSchema }),
+  workspaceController.createWorkspace
+);
 
 // Récupérer tous les workspaces de l'utilisateur connecté
-router.get('/', authMiddleware, workspaceController.getAllWorkspaces)
+router.get("/", authMiddleware, workspaceController.getAllWorkspaces);
 
 // Récupérer un workspace par ID
-router.get('/:id', authMiddleware, workspaceController.getWorkspaceById)
+router.get(
+  "/:id",
+  authMiddleware,
+  validate({ params: workspaceIdParamSchema }),
+  workspaceController.getWorkspaceById
+);
 
 // Mettre à jour un workspace
-router.put('/:id', authMiddleware, workspaceController.updateWorkspace)
+router.put(
+  "/:id",
+  authMiddleware,
+  validate({ params: workspaceIdParamSchema, body: updateWorkspaceSchema }),
+  workspaceController.updateWorkspace
+);
 
 // Supprimer un workspace
-router.delete('/:id', authMiddleware, workspaceController.deleteWorkspace)
+router.delete(
+  "/:id",
+  authMiddleware,
+  validate({ params: workspaceIdParamSchema }),
+  workspaceController.deleteWorkspace
+);
 
 // Inviter un membre dans un workspace
 router.post(
-    '/:id/invite',
+    "/:id/invite",
     authMiddleware,
+    validate({
+      params: workspaceIdParamSchema,
+      body: inviteToWorkspaceSchema
+    }),
     workspaceController.inviteToWorkspace
 )
 
 // Rejoindre un workspace via un code d'invitation
-router.post('/join', authMiddleware, workspaceController.joinWorkspace)
+router.post(
+  "/join",
+  authMiddleware,
+  validate({ body: joinWorkspaceSchema }),
+  workspaceController.joinWorkspace
+);
 
-module.exports = router
+module.exports = router;

--- a/supchat-server/validators/workspaceValidators.js
+++ b/supchat-server/validators/workspaceValidators.js
@@ -1,0 +1,33 @@
+const Joi = require("joi");
+
+const createWorkspaceSchema = Joi.object({
+  name: Joi.string().min(3).max(50).required(),
+  description: Joi.string().max(500).allow(""),
+  isPublic: Joi.boolean()
+});
+
+const updateWorkspaceSchema = Joi.object({
+  name: Joi.string().min(3).max(50),
+  description: Joi.string().max(500).allow(""),
+  isPublic: Joi.boolean()
+}).min(1);
+
+const inviteToWorkspaceSchema = Joi.object({
+  email: Joi.string().email().required()
+});
+
+const joinWorkspaceSchema = Joi.object({
+  inviteCode: Joi.string().required()
+});
+
+const workspaceIdParamSchema = Joi.object({
+  id: Joi.string().hex().length(24).required()
+});
+
+module.exports = {
+  createWorkspaceSchema,
+  updateWorkspaceSchema,
+  inviteToWorkspaceSchema,
+  joinWorkspaceSchema,
+  workspaceIdParamSchema
+};


### PR DESCRIPTION
## Summary
- add Joi validators for workspace endpoints
- add generic validation middleware using Joi
- validate workspace routes using the middleware

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run lint:fix` *(fails: Missing script)*
- `npx tsc --noEmit`
- `npm test` *(fails: jest not found)*
- `npm run test:integration` *(fails: Missing script)*
- `npm run build`
- `docker-compose config` *(fails: command not found)*
- `docker-compose logs --tail=50 | grep -i error` *(fails: command not found)*
- `npm run test:e2e` *(fails: package.json missing)*
- `curl -f http://localhost:3000/health` *(fails: connection refused)*
- `curl -f http://localhost/health` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684cb081d1c4832485db3e737948e92f