### PR TITLE
Add workspace API tests

### DIFF
--- a/supchat-server/tests/setup.js
+++ b/supchat-server/tests/setup.js
@@ -1,17 +1,16 @@
 const mongoose = require("mongoose");
 const { MongoMemoryServer } = require("mongodb-memory-server");
-const dotenv = require("dotenv");
+
 let mongoServer;
 
 beforeAll(async () => {
   mongoServer = await MongoMemoryServer.create();
-  const mongoUri = mongoServer.getUri();
-  await mongoose
-    .connect(process.env.MONGO_URI)
-    .then(() => console.log("MongoDB connected"));
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri);
 });
 
 afterAll(async () => {
+  await mongoose.connection.dropDatabase();
   await mongoose.disconnect();
   await mongoServer.stop();
 });

--- a/supchat-server/tests/workspace.test.js
+++ b/supchat-server/tests/workspace.test.js
@@ -1,0 +1,44 @@
+const request = require("supertest");
+const app = require("../src/app");
+
+describe("Test des routes Workspace", () => {
+  const fakeId = "507f191e810c19729de860ea";
+
+  it("Renvoie 401 lors de la création sans authentification", async () => {
+    const res = await request(app)
+      .post("/api/workspaces")
+      .send({ name: "Workspace Test" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("Renvoie 401 lors de la récupération", async () => {
+    const res = await request(app).get("/api/workspaces");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("Renvoie 401 lors de la mise à jour", async () => {
+    const res = await request(app)
+      .put(`/api/workspaces/${fakeId}`)
+      .send({ name: "Nouveau" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("Renvoie 401 lors de la suppression", async () => {
+    const res = await request(app).delete(`/api/workspaces/${fakeId}`);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("Renvoie 401 lors de l'invitation", async () => {
+    const res = await request(app)
+      .post(`/api/workspaces/${fakeId}/invite`)
+      .send({ email: "invite@example.com" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("Renvoie 401 lors de la jointure", async () => {
+    const res = await request(app)
+      .post("/api/workspaces/join")
+      .send({ inviteCode: fakeId });
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- update test DB setup to use mongodb-memory-server
- add workspace route tests covering CRUD and invite/join endpoints

## Testing
- `npm test --silent` *(fails: jest not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb751e62c8324996d9f0a10aa74fb