### PR TITLE
Implement workspace details page

### DIFF
--- a/client-web/src/hooks/useWorkspaceDetails.ts
+++ b/client-web/src/hooks/useWorkspaceDetails.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import {
+  getWorkspaceDetails,
+  inviteToWorkspace,
+  joinWorkspace,
+} from "@services/workspaceApi";
+
+export function useWorkspaceDetails(workspaceId: string) {
+  const [workspace, setWorkspace] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [joinCode, setJoinCode] = useState("");
+  const [joinLoading, setJoinLoading] = useState(false);
+
+  const fetchDetails = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getWorkspaceDetails(workspaceId);
+      setWorkspace(data);
+    } catch (err: any) {
+      setError(err.message || "Erreur lors du chargement");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInvite = async () => {
+    if (!inviteEmail) return;
+    setInviteLoading(true);
+    try {
+      await inviteToWorkspace(workspaceId, inviteEmail);
+      alert(`Invitation envoyée à ${inviteEmail}`);
+      setInviteEmail("");
+      fetchDetails();
+    } catch (err: any) {
+      alert(err.message || "Erreur lors de l'invitation");
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const handleJoin = async () => {
+    if (!joinCode) return;
+    setJoinLoading(true);
+    try {
+      await joinWorkspace(joinCode);
+      alert("Vous avez rejoint l'espace de travail !");
+      setJoinCode("");
+      fetchDetails();
+    } catch (err: any) {
+      alert(err.message || "Erreur lors de la jointure");
+    } finally {
+      setJoinLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDetails();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId]);
+
+  return {
+    workspace,
+    loading,
+    error,
+    inviteEmail,
+    setInviteEmail,
+    inviteLoading,
+    joinCode,
+    setJoinCode,
+    joinLoading,
+    handleInvite,
+    handleJoin,
+  };
+}

--- a/client-web/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.module.scss
+++ b/client-web/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.module.scss
@@ -1,0 +1,33 @@
+.container {
+  padding: 2.4rem;
+  margin-top: var(--header-height);
+  width: 100%;
+}
+
+.title {
+  margin-bottom: 2rem;
+}
+
+.section {
+  margin-bottom: 2.4rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.form {
+  display: flex;
+  gap: 0.8rem;
+  margin-top: 1.2rem;
+}
+
+.error {
+  color: var(--color-error);
+  margin-top: 1.2rem;
+}

--- a/client-web/src/pages/WorkspaceDetailPage/index.tsx
+++ b/client-web/src/pages/WorkspaceDetailPage/index.tsx
@@ -1,9 +1,106 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+import { useWorkspaceDetails } from "@hooks/useWorkspaceDetails";
+import styles from "./WorkspaceDetailPage.module.scss";
 
 const WorkspaceDetailPage: React.FC = () => {
-  const { id } = useParams();
-  return <h1>Détail de l'espace de travail {id}</h1>;
+  const { id } = useParams<{ id: string }>();
+  const {
+    workspace,
+    loading,
+    error,
+    inviteEmail,
+    setInviteEmail,
+    inviteLoading,
+    joinCode,
+    setJoinCode,
+    joinLoading,
+    handleInvite,
+    handleJoin,
+  } = useWorkspaceDetails(id || "");
+
+  if (loading) {
+    return <p className={styles["container"]}>Chargement...</p>;
+  }
+
+  if (error) {
+    return (
+      <div className={styles["container"]}>
+        <p className={styles["error"]}>{error}</p>
+      </div>
+    );
+  }
+
+  if (!workspace) {
+    return (
+      <div className={styles["container"]}>
+        <p className={styles["error"]}>Workspace introuvable.</p>
+      </div>
+    );
+  }
+
+  return (
+    <section className={styles["container"]}>
+      <h1 className={styles["title"]}>{workspace.name}</h1>
+      {workspace.description && <p>{workspace.description}</p>}
+
+      <div className={styles["section"]}>
+        <h2>Canaux</h2>
+        {workspace.channels && workspace.channels.length ? (
+          <ul className={styles["list"]}>
+            {workspace.channels.map((ch: any) => (
+              <li key={ch._id || ch}>{ch.name || ch}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>Aucun canal.</p>
+        )}
+      </div>
+
+      <div className={styles["section"]}>
+        <h2>Membres</h2>
+        {workspace.members && workspace.members.length ? (
+          <ul className={styles["list"]}>
+            {workspace.members.map((m: any) => (
+              <li key={m._id || m}>{m.username || m.email || m}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>Aucun membre.</p>
+        )}
+      </div>
+
+      <div className={styles["section"]}>
+        <h3>Inviter un membre</h3>
+        <div className={styles["form"]}>
+          <input
+            type="email"
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+            placeholder="Email"
+          />
+          <button onClick={handleInvite} disabled={inviteLoading}>
+            {inviteLoading ? "Envoi..." : "Inviter"}
+          </button>
+        </div>
+      </div>
+
+      <div className={styles["section"]}>
+        <h3>Rejoindre via code</h3>
+        <div className={styles["form"]}>
+          <input
+            type="text"
+            value={joinCode}
+            onChange={(e) => setJoinCode(e.target.value)}
+            placeholder="Code d'invitation"
+          />
+          <button onClick={handleJoin} disabled={joinLoading}>
+            {joinLoading ? "Rejoindre..." : "Rejoindre"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default WorkspaceDetailPage;


### PR DESCRIPTION
## Summary
- implement `useWorkspaceDetails` hook
- flesh out `WorkspaceDetailPage` using the new hook
- add basic SCSS module styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`
- `npm test` *(fails: missing package.json)*
- `npm test` in `supchat-server` *(fails: jest not found)*
- `npm run build` in `client-web` *(fails: missing dependencies)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cba0e44c883248d2a48a06f446218