### PR TITLE
Fix workspace ownership check

### DIFF
--- a/client-web/src/hooks/useWorkspacePageLogic.ts
+++ b/client-web/src/hooks/useWorkspacePageLogic.ts
@@ -48,7 +48,12 @@ export function useWorkspacePageLogic() {
   };
 
   const handleEdit = (workspace: any) => {
-    setEditModal(workspace);
+    setEditModal({
+      id: workspace._id,
+      name: workspace.name,
+      description: workspace.description,
+      isPublic: workspace.isPublic,
+    });
   };
 
   const handleEditSubmit = async (e: React.FormEvent) => {

--- a/supchat-server/controllers/workspaceController.js
+++ b/supchat-server/controllers/workspaceController.js
@@ -88,10 +88,12 @@ exports.updateWorkspace = async (req, res) => {
                 .json({ message: 'Espace de travail non trouvé' })
         }
 
+        const ownerId = workspace.owner && workspace.owner._id ? workspace.owner._id : workspace.owner
+
         let isAllowed = false
         if (isGlobalAdmin(req.user)) {
             isAllowed = true
-        } else if (String(workspace.owner) === String(req.user.id)) {
+        } else if (String(ownerId) === String(req.user.id)) {
             isAllowed = true
         }
 
@@ -124,10 +126,12 @@ exports.deleteWorkspace = async (req, res) => {
         }
         console.log('workspace', workspace)
 
+        const ownerId = workspace.owner && workspace.owner._id ? workspace.owner._id : workspace.owner
+
         let isAllowed = false
         if (isGlobalAdmin(req.user)) {
             isAllowed = true
-        } else if (String(workspace.owner) === String(req.user.id)) {
+        } else if (String(ownerId) === String(req.user.id)) {
             isAllowed = true
         }
 


### PR DESCRIPTION
## Summary
- fix workspace owner check in controller so workspace creator can modify or delete
- ensure web client sends correct workspace id when editing

## Testing
- `npm run lint` *(fails: package.json missing)*
- `npm --prefix supchat-server run lint` *(fails: Missing script)*
- `npm --prefix client-web run lint` *(fails: missing @eslint/js)*
- `npm --prefix supchat-server test` *(fails: jest not found)*
- `npm --prefix client-web test` *(fails: Missing script)*
- `npm --prefix supchat-server run test:integration` *(fails: Missing script)*
- `npm --prefix client-web run test:integration` *(fails: Missing script)*
- `npm --prefix supchat-server run build` *(succeeds with tsc help output)*
- `npm --prefix client-web run build` *(fails: missing vite deps)*
- `docker-compose config` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684cbdd3803c832488e8fa8788943319