### PR TITLE
Add reusable loader component

### DIFF
--- a/client-web/src/App.tsx
+++ b/client-web/src/App.tsx
@@ -19,6 +19,7 @@ import Header from "@components/layout/Header";
 import Footer from "@components/layout/Footer";
 import PrivateRoute from "@components/layout/PrivateRoute";
 import PublicRoute from "@components/layout/PublicRoute";
+import Loader from "@components/Loader";
 
 import Dashboard from "@pages/Dashboard";
 import WorkspacePage from "@pages/WorkspacePage";
@@ -100,11 +101,14 @@ const App: React.FC = () => {
       })
       .catch(() => {
         dispatch(logout());
+      })
+      .finally(() => {
+        dispatch(setAuthLoading(false));
       });
   }, [dispatch]);
 
   if (authLoading) {
-    return <div className="loading">Chargement...</div>;
+    return <Loader />;
   }
 
   const toggleTheme = () => {

--- a/client-web/src/components/Loader/Loader.module.scss
+++ b/client-web/src/components/Loader/Loader.module.scss
@@ -1,0 +1,23 @@
+@use "@styles/variables" as *;
+
+.loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.spinner {
+  width: 4rem;
+  height: 4rem;
+  border: 0.4rem solid var(--color-bg-secondary);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/client-web/src/components/Loader/index.tsx
+++ b/client-web/src/components/Loader/index.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import styles from "./Loader.module.scss";
+
+interface LoaderProps {
+  className?: string;
+}
+
+const Loader: React.FC<LoaderProps> = ({ className }) => {
+  return (
+    <div className={`${styles["loader"]} ${className || ""}`.trim()} role="status" aria-label="Chargement">
+      <div className={styles["spinner"]} />
+    </div>
+  );
+};
+
+export default Loader;

--- a/client-web/src/components/layout/PrivateRoute/index.tsx
+++ b/client-web/src/components/layout/PrivateRoute/index.tsx
@@ -3,13 +3,14 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { RootState } from "@store/store";
+import Loader from "@components/Loader";
 
 const PrivateRoute: React.FC = () => {
   const user = useSelector((state: RootState) => state.auth.user);
   const authLoading = useSelector((state: RootState) => state.auth.isLoading);
 
   if (authLoading) {
-    return <div className="loading">Chargement...</div>;
+    return <Loader />;
   }
 
   return user ? <Outlet /> : <Navigate to="/login" replace />;

--- a/client-web/src/components/layout/PublicRoute/index.tsx
+++ b/client-web/src/components/layout/PublicRoute/index.tsx
@@ -3,13 +3,14 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { RootState } from "@store/store";
+import Loader from "@components/Loader";
 
 const PublicRoute: React.FC = () => {
   const user = useSelector((state: RootState) => state.auth.user);
   const authLoading = useSelector((state: RootState) => state.auth.isLoading);
 
   if (authLoading) {
-    return <div className="loading">Chargement...</div>;
+    return <Loader />;
   }
 
   // If the user is logged in => redirect to dashboard (or other)

--- a/client-web/src/pages/InviteWorkspacePage/index.tsx
+++ b/client-web/src/pages/InviteWorkspacePage/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import type { RootState } from "@store/store";
 import { joinWorkspace } from "@services/workspaceApi";
+import Loader from "@components/Loader";
 
 const InvitePage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -36,7 +37,7 @@ const InvitePage: React.FC = () => {
   }, [user, isLoading, navigate, id]);
 
   if (isLoading) {
-    return <p>Chargement...</p>;
+    return <Loader />;
   }
 
   if (!user) {

--- a/client-web/src/pages/WorkspaceDetailPage/index.tsx
+++ b/client-web/src/pages/WorkspaceDetailPage/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import { useWorkspaceDetails } from "@hooks/useWorkspaceDetails";
 import styles from "./WorkspaceDetailPage.module.scss";
+import Loader from "@components/Loader";
 
 const WorkspaceDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -22,7 +23,11 @@ const WorkspaceDetailPage: React.FC = () => {
   } = useWorkspaceDetails(id || "");
 
   if (loading) {
-    return <p className={styles["container"]}>Chargement...</p>;
+    return (
+      <div className={styles["container"]}>
+        <Loader />
+      </div>
+    );
   }
 
   if (error) {

--- a/client-web/src/pages/WorkspacePage/index.tsx
+++ b/client-web/src/pages/WorkspacePage/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorkspaceCreateForm from "@components/Workspace/WorkspaceCreateForm";
 import WorkspaceList from "@components/Workspace/WorkspaceList";
+import Loader from "@components/Loader";
 import styles from "./WorkspacePage.module.scss";
 import { useWorkspacePageLogic } from "@hooks/useWorkspacePageLogic";
 import { useSelector } from "react-redux";
@@ -162,7 +163,7 @@ const WorkspacesPage: React.FC = () => {
       )}
 
       {loading ? (
-        <p>Chargement...</p>
+        <Loader />
       ) : error ? (
         <p className={styles["error"]}>{error}</p>
       ) : (


### PR DESCRIPTION
## Summary
- create Loader component with SCSS spinner
- show Loader during auth and workspace loading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: Cannot find module 'vite')*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd38598188324bc0ff7df656e8350