### PR TITLE
Fix channel filter for workspace

### DIFF
--- a/supchat-server/controllers/channelController.js
+++ b/supchat-server/controllers/channelController.js
@@ -33,7 +33,7 @@ exports.getChannels = async (req, res) => {
       return res.status(400).json({ message: "ID du workspace requis" });
     }
 
-    const channels = await Channel.find({ workspaceId });
+    const channels = await Channel.find({ workspace: workspaceId });
     return res.status(200).json(channels);
   } catch (error) {
     return res.status(500).json({ message: "Erreur serveur", error });

--- a/supchat-server/tests/channel.test.js
+++ b/supchat-server/tests/channel.test.js
@@ -4,17 +4,27 @@ const Channel = require("../models/Channel");
 
 describe("Test des routes Channel", () => {
   let channelId;
+  const workspaceId = "507f191e810c19729de860ea";
 
   it("Crée un nouveau canal", async () => {
     const res = await request(app).post("/api/channels/create").send({
       name: "Général",
       type: "public",
-      workspaceId: "1234567890",
+      workspaceId,
     });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.name).toBe("Général");
-    channelId = res.body._id;
+    channelId = res.body.channel._id;
+  });
+
+  it("Filtre les canaux par workspace", async () => {
+    await Channel.create({ name: "Filtre", type: "public", workspace: workspaceId });
+
+    const res = await request(app).get(`/api/channels?workspaceId=${workspaceId}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.some((c) => c.workspace === workspaceId)).toBe(true);
   });
 
   it("Récupère un canal", async () => {


### PR DESCRIPTION
## Summary
- correct Channel.find usage in channel controller
- verify filtering channels by workspace via unit test

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run lint:fix` *(fails: Missing script)*
- `npx tsc --noEmit`
- `npm test` *(fails: jest not found)*
- `npm run test:integration` *(fails: Missing script)*
- `npm run build`
- `docker-compose config` *(fails: command not found)*
- `docker-compose up -d` *(fails: command not found)*
- `curl -f http://localhost:3000/health` *(fails: couldn't connect)*
- `curl -f http://localhost/health` *(fails: couldn't connect)*
- `npm run test:e2e` *(fails: ENOENT package.json)*
- `docker-compose logs --tail=50 | grep -i error` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdf7cf188832491f10af887dac2e1