### PR TITLE
Fix channel routes and tests

### DIFF
--- a/supchat-server/routes/channel.Routes.js
+++ b/supchat-server/routes/channel.Routes.js
@@ -6,13 +6,40 @@ const {
   updateChannel,
   deleteChannel,
 } = require("../controllers/channelController");
+const { authMiddleware } = require("../middlewares/authMiddleware");
+const { validate } = require("../middlewares/validationMiddleware");
+const {
+  createChannelSchema,
+  updateChannelSchema,
+  channelIdParamSchema,
+} = require("../validators/channelValidators");
 
 const router = express.Router();
 
-router.post("/", createChannel);
-router.get("/", getChannels);
-router.get("/:id", getChannelById);
-router.put("/edit/:id", updateChannel);
-router.delete("/:id", deleteChannel);
+router.post(
+  "/",
+  authMiddleware,
+  validate({ body: createChannelSchema }),
+  createChannel
+);
+router.get("/", authMiddleware, getChannels);
+router.get(
+  "/:id",
+  authMiddleware,
+  validate({ params: channelIdParamSchema }),
+  getChannelById
+);
+router.put(
+  "/:id",
+  authMiddleware,
+  validate({ params: channelIdParamSchema, body: updateChannelSchema }),
+  updateChannel
+);
+router.delete(
+  "/:id",
+  authMiddleware,
+  validate({ params: channelIdParamSchema }),
+  deleteChannel
+);
 
 module.exports = router;

--- a/supchat-server/tests/channel.test.js
+++ b/supchat-server/tests/channel.test.js
@@ -6,15 +6,22 @@ describe("Test des routes Channel", () => {
   let channelId;
 
   it("Crée un nouveau canal", async () => {
-    const res = await request(app).post("/api/channels/create").send({
+    const res = await request(app).post("/api/channels").send({
       name: "Général",
       type: "public",
-      workspaceId: "1234567890",
+      workspaceId: "507f191e810c19729de860ea",
     });
 
     expect(res.statusCode).toBe(201);
     expect(res.body.name).toBe("Général");
     channelId = res.body._id;
+  });
+
+  it("Met à jour un canal", async () => {
+    const res = await request(app)
+      .put(`/api/channels/${channelId}`)
+      .send({ name: "Général 2" });
+    expect(res.statusCode).toBe(200);
   });
 
   it("Récupère un canal", async () => {

--- a/supchat-server/validators/channelValidators.js
+++ b/supchat-server/validators/channelValidators.js
@@ -1,0 +1,23 @@
+const Joi = require("joi");
+
+const createChannelSchema = Joi.object({
+  name: Joi.string().min(3).max(50).required(),
+  workspaceId: Joi.string().hex().length(24).required(),
+  description: Joi.string().max(500).allow(""),
+  type: Joi.string().valid("public", "private").required()
+});
+
+const updateChannelSchema = Joi.object({
+  name: Joi.string().min(3).max(50),
+  description: Joi.string().max(500).allow("")
+}).min(1);
+
+const channelIdParamSchema = Joi.object({
+  id: Joi.string().hex().length(24).required()
+});
+
+module.exports = {
+  createChannelSchema,
+  updateChannelSchema,
+  channelIdParamSchema
+};


### PR DESCRIPTION
## Summary
- protect channel routes with auth and validation
- switch edit PUT endpoint to `/api/channels/:id`
- validate channel data using new Joi schemas
- adjust channel tests for new endpoints

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run test:integration` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run lint:fix` *(fails: Missing script)*
- `npx tsc --noEmit`
- `npm run build`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce376c3a48324ba56aa1968ebe83e