### PR TITLE
Update message channel route

### DIFF
--- a/client-mobile/app/(drawer)/messages.tsx
+++ b/client-mobile/app/(drawer)/messages.tsx
@@ -31,7 +31,7 @@ export default function MessagesScreen() {
   const fetchMessages = async () => {
     try {
       const res = await axios.get(
-        `http://localhost:3000/api/messages?channelId=${channelId}`
+        `http://localhost:3000/api/messages/channel/${channelId}`
       );
       setMessages(res.data.reverse());
     } catch (err) {

--- a/supchat-server/public/swagger/swagger-output.json
+++ b/supchat-server/public/swagger/swagger-output.json
@@ -815,7 +815,7 @@
         }
       }
     },
-    "/api/messages/{channelId}": {
+    "/api/messages/channel/{channelId}": {
       "get": {
         "description": "",
         "parameters": [

--- a/supchat-server/routes/message.Routes.js
+++ b/supchat-server/routes/message.Routes.js
@@ -9,7 +9,7 @@ const {
 const router = express.Router();
 
 router.post("/", sendMessage);
-router.get("/:channelId", getMessagesByChannel);
+router.get("/channel/:channelId", getMessagesByChannel);
 router.get("/:id", getMessageById);
 router.delete("/:id", deleteMessage);
 


### PR DESCRIPTION
## Summary
- adjust channel message GET route on server
- update swagger spec for new route
- update mobile client to use `/messages/channel/:channelId`

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run lint:fix` *(fails: Missing script)*
- `npx tsc --noEmit`
- `npm test` *(fails: jest not found)*
- `npm run test:integration` *(fails: Missing script)*
- `npm run build`
- `docker-compose config` *(fails: command not found)*
- `npm run lint` in client-mobile *(fails: expo not found)*
- `npx tsc --noEmit` in client-mobile *(fails: missing modules)*
- `npm test` in client-mobile *(fails: jest not found)*
- `npm run test:integration` in client-mobile *(fails: Missing script)*
- `npm run build` in client-mobile *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cef4841e083248a379be5f4467498