### PR TITLE
Add channels API and slice

### DIFF
--- a/client-web/src/services/channelApi.ts
+++ b/client-web/src/services/channelApi.ts
@@ -1,0 +1,81 @@
+import api, { fetchCsrfToken } from "@utils/axiosInstance";
+
+export interface ChannelFormData {
+  name: string;
+  workspaceId: string;
+  description?: string;
+  type?: string;
+}
+
+export async function getChannels(workspaceId: string) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.get("/channels", { params: { workspaceId } });
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message ||
+        err.message ||
+        "Erreur lors du chargement des canaux"
+    );
+  }
+}
+
+export async function createChannel(formData: ChannelFormData) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.post("/channels", formData);
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message ||
+        err.message ||
+        "Erreur lors de la création du canal"
+    );
+  }
+}
+
+export async function updateChannel(
+  channelId: string,
+  formData: Partial<Omit<ChannelFormData, "workspaceId">>
+) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.put(`/channels/${channelId}`, formData);
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message ||
+        err.message ||
+        "Erreur lors de la mise à jour du canal"
+    );
+  }
+}
+
+export async function deleteChannel(channelId: string) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.delete(`/channels/${channelId}`);
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message ||
+        err.message ||
+        "Erreur lors de la suppression du canal"
+    );
+  }
+}
+
+export async function getChannelById(channelId: string) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.get(`/channels/${channelId}`);
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message ||
+        err.message ||
+        "Erreur lors de la récupération du canal"
+    );
+  }
+}

--- a/client-web/src/store/channelsSlice.ts
+++ b/client-web/src/store/channelsSlice.ts
@@ -1,0 +1,108 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  getChannels,
+  createChannel,
+  updateChannel,
+  deleteChannel,
+  ChannelFormData,
+} from "@services/channelApi";
+
+export const fetchChannels = createAsyncThunk(
+  "channels/fetchAll",
+  async (workspaceId: string) => {
+    return await getChannels(workspaceId);
+  }
+);
+
+export const addChannel = createAsyncThunk(
+  "channels/add",
+  async (formData: ChannelFormData) => {
+    await createChannel(formData);
+    return await getChannels(formData.workspaceId);
+  }
+);
+
+export const editChannel = createAsyncThunk(
+  "channels/edit",
+  async (
+    params: {
+      channelId: string;
+      workspaceId: string;
+      data: Partial<Omit<ChannelFormData, "workspaceId">>;
+    }
+  ) => {
+    await updateChannel(params.channelId, params.data);
+    return await getChannels(params.workspaceId);
+  }
+);
+
+export const removeChannel = createAsyncThunk(
+  "channels/remove",
+  async (params: { channelId: string; workspaceId: string }) => {
+    await deleteChannel(params.channelId);
+    return await getChannels(params.workspaceId);
+  }
+);
+
+const channelsSlice = createSlice({
+  name: "channels",
+  initialState: {
+    items: [] as any[],
+    loading: false,
+    error: null as string | null,
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchChannels.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchChannels.fulfilled, (state, action) => {
+        state.items = action.payload;
+        state.loading = false;
+      })
+      .addCase(fetchChannels.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Erreur lors du chargement";
+      })
+      .addCase(addChannel.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(addChannel.fulfilled, (state, action) => {
+        state.items = action.payload;
+        state.loading = false;
+      })
+      .addCase(addChannel.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Erreur lors de la création";
+      })
+      .addCase(editChannel.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(editChannel.fulfilled, (state, action) => {
+        state.items = action.payload;
+        state.loading = false;
+      })
+      .addCase(editChannel.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Erreur lors de la mise à jour";
+      })
+      .addCase(removeChannel.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(removeChannel.fulfilled, (state, action) => {
+        state.items = action.payload;
+        state.loading = false;
+      })
+      .addCase(removeChannel.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Erreur lors de la suppression";
+      });
+  },
+});
+
+export default channelsSlice.reducer;

--- a/client-web/src/store/store.ts
+++ b/client-web/src/store/store.ts
@@ -1,13 +1,15 @@
 // src/store/store.ts
 
-import { configureStore } from '@reduxjs/toolkit';
-import authReducer from '@store/authSlice';
-import workspacesReducer from '@store/workspacesSlice';
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "@store/authSlice";
+import workspacesReducer from "@store/workspacesSlice";
+import channelsReducer from "@store/channelsSlice";
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     workspaces: workspacesReducer,
+    channels: channelsReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- implement channel API helper with axios
- create Redux slice for channels using createAsyncThunk
- register channels slice in store

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx tsc --noEmit`
- `npm run build` *(fails: missing type definitions)*
- `docker-compose config` *(fails: command not found)*
- `npm test` *(fails: missing script)*
- `npm run test:integration` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cf2220e9483249811bbc5e16a1e65