### PR TITLE
Add basic channel management

### DIFF
--- a/client-web/src/components/Channel/ChannelCreateForm/ChannelCreateForm.module.scss
+++ b/client-web/src/components/Channel/ChannelCreateForm/ChannelCreateForm.module.scss
@@ -1,0 +1,38 @@
+.title {
+  margin-bottom: 1.2rem;
+  text-align: center;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.input {
+  width: 100%;
+  padding: 0.8rem 1.2rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-bg-input);
+  font-size: 1.4rem;
+}
+
+.label-description {
+  margin-top: 1rem;
+}
+
+.container-btn {
+  display: flex;
+  justify-content: center;
+}
+
+.error {
+  color: var(--color-error);
+  font-size: var(--font-size-m);
+  text-align: center;
+}
+
+.inputError {
+  border: 1.5px solid var(--color-error) !important;
+}

--- a/client-web/src/components/Channel/ChannelCreateForm/index.tsx
+++ b/client-web/src/components/Channel/ChannelCreateForm/index.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { useChannelCreateForm } from "@hooks/useChannelCreateForm";
+import styles from "./ChannelCreateForm.module.scss";
+
+interface ChannelCreateFormProps {
+  workspaceId: string;
+  onCreate: (formData: { name: string; description?: string; workspaceId: string }) => Promise<void>;
+  onCreated?: () => void;
+}
+
+const ChannelCreateForm: React.FC<ChannelCreateFormProps> = ({
+  workspaceId,
+  onCreate,
+  onCreated,
+}) => {
+  const {
+    name,
+    setName,
+    description,
+    setDescription,
+    loading,
+    error,
+    handleSubmit,
+  } = useChannelCreateForm(onCreate, workspaceId, onCreated);
+
+  return (
+    <form onSubmit={handleSubmit} className={styles["form"]}>
+      <h2 className={styles["title"]}>Créer un canal</h2>
+      <label htmlFor="channel-name">
+        Nom&nbsp;:
+        <input
+          id="channel-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className={`${styles["input"]} ${error?.includes("nom") ? styles["inputError"] : ""}`}
+          disabled={loading}
+          required
+        />
+        {error?.includes("nom") && <p className={styles["error"]}>{error}</p>}
+      </label>
+      <label htmlFor="channel-description" className={styles["label-description"]}>
+        Description&nbsp;:
+        <input
+          id="channel-description"
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className={`${styles["input"]} ${error?.includes("description") ? styles["inputError"] : ""}`}
+          disabled={loading}
+        />
+        {error?.includes("description") && (
+          <p className={styles["error"]}>{error}</p>
+        )}
+      </label>
+      {error && !error.includes("nom") && !error.includes("description") && (
+        <p className={styles["error"]}>{error}</p>
+      )}
+      <div className={styles["container-btn"]}>
+        <button type="submit" disabled={loading} className={`btn ${styles["submitButton"]}`}>
+          {loading ? "Création..." : "Créer"}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ChannelCreateForm;

--- a/client-web/src/components/Channel/ChannelList/ChannelList.module.scss
+++ b/client-web/src/components/Channel/ChannelList/ChannelList.module.scss
@@ -1,0 +1,36 @@
+.channel-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.channel-item {
+  padding: 1.2rem 1.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-bg-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.channel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.channel-badge {
+  font-size: 1.1rem;
+  background: var(--color-bg-secondary);
+  padding: 0.2rem 0.8rem;
+  border-radius: 0.8rem;
+}
+
+.channel-description {
+  font-size: 1.3rem;
+  color: var(--color-text-secondary);
+}

--- a/client-web/src/components/Channel/ChannelList/index.tsx
+++ b/client-web/src/components/Channel/ChannelList/index.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import styles from "./ChannelList.module.scss";
+
+export type Channel = {
+  _id: string;
+  name: string;
+  description?: string;
+  type?: string;
+};
+
+interface ChannelListProps {
+  channels: Channel[];
+  onAccess?: (channel: Channel) => void;
+}
+
+const ChannelList: React.FC<ChannelListProps> = ({ channels, onAccess }) => {
+  if (!channels.length) {
+    return <p>Aucun canal pour le moment.</p>;
+  }
+
+  return (
+    <ul className={styles["channel-list"]}>
+      {channels.map((ch) => (
+        <li key={ch._id} className={styles["channel-item"]}>
+          <div className={styles["channel-header"]}>
+            <strong>{ch.name}</strong>
+            {ch.type && <span className={styles["channel-badge"]}>{ch.type}</span>}
+          </div>
+          {ch.description && (
+            <p className={styles["channel-description"]}>{ch.description}</p>
+          )}
+          {onAccess && (
+            <button
+              type="button"
+              className="btn"
+              onClick={() => onAccess(ch)}
+            >
+              Ouvrir
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ChannelList;

--- a/client-web/src/hooks/useChannelCreateForm.ts
+++ b/client-web/src/hooks/useChannelCreateForm.ts
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { channelCreateSchema } from "@utils/validation";
+import type { ChannelFormData } from "@services/channelApi";
+
+export function useChannelCreateForm(
+  onCreate: (formData: ChannelFormData) => Promise<void>,
+  workspaceId: string,
+  onCreated?: () => void
+) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await channelCreateSchema.validate({ name, description });
+    } catch (validationError: any) {
+      setError(validationError.message);
+      return;
+    }
+    setLoading(true);
+    try {
+      await onCreate({ name, description, workspaceId });
+      setName("");
+      setDescription("");
+      if (onCreated) onCreated();
+    } catch (err: any) {
+      setError(err.message || "Erreur lors de la création.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    name,
+    setName,
+    description,
+    setDescription,
+    loading,
+    error,
+    handleSubmit,
+  };
+}

--- a/client-web/src/hooks/useChannels.ts
+++ b/client-web/src/hooks/useChannels.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import type { RootState, AppDispatch } from "@store/store";
+import {
+  fetchChannels,
+  addChannel,
+} from "@store/channelsSlice";
+import type { ChannelFormData } from "@services/channelApi";
+
+export function useChannels(workspaceId: string) {
+  const dispatch = useDispatch<AppDispatch>();
+  const channels = useSelector((state: RootState) => state.channels.items);
+  const loading = useSelector((state: RootState) => state.channels.loading);
+  const error = useSelector((state: RootState) => state.channels.error);
+
+  const fetchAll = () => {
+    if (workspaceId) {
+      dispatch(fetchChannels(workspaceId));
+    }
+  };
+
+  const handleCreateChannel = async (formData: Omit<ChannelFormData, "workspaceId">) => {
+    if (!workspaceId) return;
+    await dispatch(addChannel({ ...formData, workspaceId }));
+  };
+
+  useEffect(() => {
+    fetchAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId]);
+
+  return { channels, loading, error, fetchChannels: fetchAll, handleCreateChannel };
+}

--- a/client-web/src/pages/WorkspaceDetailPage/index.tsx
+++ b/client-web/src/pages/WorkspaceDetailPage/index.tsx
@@ -5,6 +5,10 @@ import styles from "./WorkspaceDetailPage.module.scss";
 import Loader from "@components/Loader";
 import { useSelector } from "react-redux";
 import type { RootState } from "@store/store";
+import ChannelList from "@components/Channel/ChannelList";
+import ChannelCreateForm from "@components/Channel/ChannelCreateForm";
+import { useChannels } from "@hooks/useChannels";
+import { useNavigate } from "react-router-dom";
 
 const WorkspaceDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -21,6 +25,14 @@ const WorkspaceDetailPage: React.FC = () => {
     setInviteSuccess,
     handleInvite,
   } = useWorkspaceDetails(id || "");
+  const navigate = useNavigate();
+  const {
+    channels,
+    loading: channelsLoading,
+    error: channelsError,
+    fetchChannels,
+    handleCreateChannel,
+  } = useChannels(id || "");
 
   if (loading) {
     return (
@@ -51,6 +63,10 @@ const WorkspaceDetailPage: React.FC = () => {
     user &&
     workspace.owner &&
     (user.role === "admin" || user.email === workspace.owner.email);
+
+  const handleChannelAccess = (channel: any) => {
+    navigate(`/message?channel=${channel._id}`);
+  };
 
   return (
     <section className={styles["container"]}>
@@ -131,6 +147,29 @@ const WorkspaceDetailPage: React.FC = () => {
             {inviteSuccess && !inviteError && (
               <div className={styles["success"]}>{inviteSuccess}</div>
             )}
+          </div>
+        )}
+      </div>
+
+      {/* Section canaux */}
+      <div className={styles["sectionGrid"]}>
+        <div className={styles["section"]}>
+          <h2>Canaux</h2>
+          {channelsLoading ? (
+            <Loader />
+          ) : channelsError ? (
+            <p className={styles["error"]}>{channelsError}</p>
+          ) : (
+            <ChannelList channels={channels} onAccess={handleChannelAccess} />
+          )}
+        </div>
+        {isAdminOrOwner && (
+          <div className={styles["section"]}>
+            <ChannelCreateForm
+              workspaceId={id || ""}
+              onCreate={handleCreateChannel}
+              onCreated={fetchChannels}
+            />
           </div>
         )}
       </div>

--- a/client-web/src/utils/validation.ts
+++ b/client-web/src/utils/validation.ts
@@ -76,3 +76,16 @@ export const workspaceCreateSchema = yup.object().shape({
     .max(200, 'La description doit faire 200 caractères max'),
   isPublic: yup.boolean(),
 });
+export const channelCreateSchema = yup.object().shape({
+  name: yup
+    .string()
+    .trim()
+    .required("Le nom du canal est requis")
+    .min(3, "Le nom doit faire au moins 3 caractères")
+    .max(50, "Le nom doit faire 50 caractères max"),
+  description: yup
+    .string()
+    .min(3, "La description doit faire au moins 3 caractères")
+    .max(200, "La description doit faire 200 caractères max"),
+});
+


### PR DESCRIPTION
## Summary
- create `ChannelList` and `ChannelCreateForm` components
- add channel creation hook and validation
- fetch/display channels in `WorkspaceDetailPage`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm test` *(fails: missing script)*
- `npm run test:integration` *(fails: missing script)*
- `npm run build` *(fails: missing deps)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf32777048324b1593207b8b87117