### PR TITLE
Implement socket.io chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,4 @@ REACT_APP_ENV=production
 # React Native mobile client configuration
 REACT_NATIVE_API_URL=http://localhost:3000
 REACT_NATIVE_ENV=production
+WEBSOCKET_URL=ws://localhost:3000

--- a/client-web/package.json
+++ b/client-web/package.json
@@ -19,7 +19,8 @@
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.2.0",
     "sass": "^1.85.0",
-    "yup": "^1.6.1"
+    "yup": "^1.6.1",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/client-web/src/hooks/useMessages.ts
+++ b/client-web/src/hooks/useMessages.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "@store/store";
+import {
+  fetchMessages,
+  addMessage,
+  pushMessage,
+} from "@store/messagesSlice";
+import { useSocket } from "@hooks/useSocket";
+
+export function useMessages(channelId: string) {
+  const dispatch = useDispatch<AppDispatch>();
+  const socket = useSocket(channelId);
+
+  const messages = useSelector((state: RootState) => state.messages.items);
+  const loading = useSelector((state: RootState) => state.messages.loading);
+  const error = useSelector((state: RootState) => state.messages.error);
+
+  const send = async (text: string) => {
+    if (!channelId) return;
+    await dispatch(addMessage({ channelId, text }));
+  };
+
+  useEffect(() => {
+    if (channelId) {
+      dispatch(fetchMessages(channelId));
+    }
+  }, [channelId, dispatch]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handler = (msg: any) => {
+      dispatch(pushMessage(msg));
+    };
+    socket.on("newMessage", handler);
+    return () => {
+      socket.off("newMessage", handler);
+    };
+  }, [socket, dispatch]);
+
+  return { messages, loading, error, send };
+}

--- a/client-web/src/hooks/useSocket.ts
+++ b/client-web/src/hooks/useSocket.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { io, Socket } from "socket.io-client";
+
+export function useSocket(channelId?: string) {
+  const [socket, setSocket] = useState<Socket | null>(null);
+
+  useEffect(() => {
+    const s = io(import.meta.env.VITE_WEBSOCKET_URL as string, {
+      withCredentials: true,
+    });
+    setSocket(s);
+    return () => {
+      s.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!socket || !channelId) return;
+    socket.emit("joinChannel", channelId);
+    return () => {
+      socket.emit("leaveChannel", channelId);
+    };
+  }, [socket, channelId]);
+
+  return socket;
+}

--- a/client-web/src/pages/MessagesPage/MessagesPage.module.scss
+++ b/client-web/src/pages/MessagesPage/MessagesPage.module.scss
@@ -1,1 +1,14 @@
-// src/pages/MessagesPage/MessagesPage.module.scss
+.container {
+  padding: 1rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+}
+
+.form {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/client-web/src/pages/MessagesPage/index.tsx
+++ b/client-web/src/pages/MessagesPage/index.tsx
@@ -1,9 +1,41 @@
-// src/pages/MessagesPage/MessagesPage.tsx
-
-// import styles from './MessagesPage.module.scss'
+import { useSearchParams } from "react-router-dom";
+import { useState } from "react";
+import { useMessages } from "@hooks/useMessages";
+import styles from "./MessagesPage.module.scss";
 
 function MessagesPage() {
-  return <h1>Mes messages</h1>;
+  const [params] = useSearchParams();
+  const channelId = params.get("channel") || "";
+  const { messages, loading, send } = useMessages(channelId);
+  const [text, setText] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    await send(text.trim());
+    setText("");
+  };
+
+  return (
+    <section className={styles["container"]}>
+      <ul className={styles["list"]}>
+        {messages.map((m: any) => (
+          <li key={m._id}>{m.text || m.content}</li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit} className={styles["form"]}>
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          disabled={loading}
+        />
+        <button type="submit" disabled={loading}>
+          Envoyer
+        </button>
+      </form>
+    </section>
+  );
 }
 
 export default MessagesPage;

--- a/client-web/src/services/messageApi.ts
+++ b/client-web/src/services/messageApi.ts
@@ -1,0 +1,30 @@
+import api, { fetchCsrfToken } from "@utils/axiosInstance";
+
+export interface MessageFormData {
+  channelId: string;
+  text: string;
+}
+
+export async function getMessages(channelId: string) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.get(`/messages/channel/${channelId}`);
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message || err.message || "Erreur lors du chargement"
+    );
+  }
+}
+
+export async function sendMessage(formData: MessageFormData) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.post("/messages", formData);
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message || err.message || "Erreur lors de l'envoi"
+    );
+  }
+}

--- a/client-web/src/store/messagesSlice.ts
+++ b/client-web/src/store/messagesSlice.ts
@@ -1,0 +1,61 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { getMessages, sendMessage, MessageFormData } from "@services/messageApi";
+
+export const fetchMessages = createAsyncThunk(
+  "messages/fetchAll",
+  async (channelId: string) => {
+    return await getMessages(channelId);
+  }
+);
+
+export const addMessage = createAsyncThunk(
+  "messages/add",
+  async (formData: MessageFormData) => {
+    await sendMessage(formData);
+    return await getMessages(formData.channelId);
+  }
+);
+
+const messagesSlice = createSlice({
+  name: "messages",
+  initialState: {
+    items: [] as any[],
+    loading: false,
+    error: null as string | null,
+  },
+  reducers: {
+    pushMessage: (state, action) => {
+      state.items.push(action.payload);
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchMessages.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchMessages.fulfilled, (state, action) => {
+        state.items = action.payload;
+        state.loading = false;
+      })
+      .addCase(fetchMessages.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Erreur lors du chargement";
+      })
+      .addCase(addMessage.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(addMessage.fulfilled, (state, action) => {
+        state.items = action.payload;
+        state.loading = false;
+      })
+      .addCase(addMessage.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Erreur lors de l'envoi";
+      });
+  },
+});
+
+export const { pushMessage } = messagesSlice.actions;
+export default messagesSlice.reducer;

--- a/client-web/src/store/store.ts
+++ b/client-web/src/store/store.ts
@@ -4,12 +4,14 @@ import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "@store/authSlice";
 import workspacesReducer from "@store/workspacesSlice";
 import channelsReducer from "@store/channelsSlice";
+import messagesReducer from "@store/messagesSlice";
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     workspaces: workspacesReducer,
     channels: channelsReducer,
+    messages: messagesReducer,
   },
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - .env
     environment:
       - VITE_REACT_APP_API_URL=${VITE_REACT_APP_API_URL}
+      - VITE_WEBSOCKET_URL=${WEBSOCKET_URL}
     depends_on:
       - api
     restart: unless-stopped

--- a/supchat-server/controllers/messageController.js
+++ b/supchat-server/controllers/messageController.js
@@ -1,5 +1,6 @@
 const Message = require("../models/Message"); // Assure-toi que le modèle Message existe
 const Channel = require("../models/Channel"); // Assure-toi que le modèle Channel existe
+const { getIo } = require("../socket");
 
 // ✅ Envoyer un message dans un canal
 exports.sendMessage = async (req, res) => {
@@ -24,6 +25,12 @@ exports.sendMessage = async (req, res) => {
     });
 
     await message.save();
+    try {
+      const io = getIo();
+      io.to(channelId).emit("newMessage", message);
+    } catch (e) {
+      console.error("Socket emit error", e);
+    }
 
     return res.status(201).json({ message: "Message envoyé.", data: message });
   } catch (error) {

--- a/supchat-server/package.json
+++ b/supchat-server/package.json
@@ -39,7 +39,8 @@
     "pug": "^3.0.3",
     "resend": "^4.5.2",
     "serve-favicon": "^2.3.0",
-    "swagger-jsdoc": "^6.2.8"
+    "swagger-jsdoc": "^6.2.8",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/supchat-server/socket.js
+++ b/supchat-server/socket.js
@@ -1,0 +1,34 @@
+const { Server } = require("socket.io");
+
+let io;
+
+function initSocket(server, allowedOrigins = ["http://localhost:5173", "http://localhost:3000"]) {
+  io = new Server(server, {
+    cors: {
+      origin: allowedOrigins,
+      methods: ["GET", "POST"],
+      credentials: true,
+    },
+  });
+
+  io.on("connection", (socket) => {
+    socket.on("joinChannel", (channelId) => {
+      if (channelId) socket.join(channelId);
+    });
+
+    socket.on("leaveChannel", (channelId) => {
+      if (channelId) socket.leave(channelId);
+    });
+  });
+
+  return io;
+}
+
+function getIo() {
+  if (!io) {
+    throw new Error("Socket.io not initialized");
+  }
+  return io;
+}
+
+module.exports = { initSocket, getIo };

--- a/supchat-server/src/app.js
+++ b/supchat-server/src/app.js
@@ -2,6 +2,7 @@
 
 const express = require('express')
 const mongoose = require('mongoose')
+const http = require('http')
 const dotenv = require('dotenv')
 const swaggerUi = require('swagger-ui-express')
 const swaggerFile = require('../public/swagger/swagger-output.json')
@@ -14,6 +15,9 @@ dotenv.config()
 
 const app = express()
 const port = process.env.PORT
+const server = http.createServer(app)
+const { initSocket } = require('../socket')
+const io = initSocket(server, ['http://localhost:5173', 'http://localhost:3000'])
 
 const allowedOrigins = ['http://localhost:5173', 'http://localhost:3000']
 
@@ -130,7 +134,7 @@ app.use((err, req, res, next) => {
 })
 
 // ==== START ==== //
-app.listen(port, () => {
+server.listen(port, () => {
     console.log(`Server running on http://localhost:${port}`)
     console.log(
         `Swagger docs available at http://localhost:${port}/api-docs/swagger-ui.html`
@@ -140,6 +144,8 @@ app.listen(port, () => {
 // Export for controllers (needed for generateCsrfToken in authController)
 module.exports = {
     app,
+    io,
+    server,
     generateCsrfToken,
     csrfMiddleware,
     invalidCsrfTokenError,


### PR DESCRIPTION
## Summary
- enable Socket.IO on the server and expose connection helpers
- emit `newMessage` event when a message is saved
- add socket.io client utilities on the web app
- provide hooks and Redux slice for real-time messages
- update Messages page with live list and send form
- adjust Docker and environment variables

## Testing
- `npx tsc --noEmit -p client-web/tsconfig.json` *(fails: npm install not available)*

------
https://chatgpt.com/codex/tasks/task_e_684cfff77d2083249877e67638a424db