### PR TITLE
Implement basic search feature

### DIFF
--- a/client-web/src/App.tsx
+++ b/client-web/src/App.tsx
@@ -30,6 +30,7 @@ import ForgotPasswordPage from "@pages/ForgotPasswordPage";
 import ResetPasswordPage from "@pages/ResetPasswordPage";
 import WorkspaceDetailPage from "@pages/WorkspaceDetailPage";
 import InviteWorkspacePage from "@pages/InviteWorkspacePage";
+import SearchPage from "@pages/SearchPage";
 
 const AppContent = ({
   theme,
@@ -66,9 +67,10 @@ const AppContent = ({
           <Route element={<PrivateRoute />}>
             <Route path="/" element={<Dashboard />} />
             <Route path="/workspace" element={<WorkspacePage />} />
-            <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
-            <Route path="/message" element={<MessagesPage />} />
-          </Route>
+          <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
+          <Route path="/message" element={<MessagesPage />} />
+          <Route path="/search" element={<SearchPage />} />
+        </Route>
         </Routes>
       </main>
 

--- a/client-web/src/components/SearchBar/SearchBar.module.scss
+++ b/client-web/src/components/SearchBar/SearchBar.module.scss
@@ -1,0 +1,44 @@
+.container {
+  position: relative;
+  width: 100%;
+}
+
+.input {
+  width: 100%;
+  padding: 0.8rem 1.2rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-bg-input);
+}
+
+.results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-top: none;
+  max-height: 20rem;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  z-index: 1000;
+}
+
+.result-item {
+  padding: 0.8rem 1.2rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.result-item:last-child {
+  border-bottom: none;
+}
+
+.type-heading {
+  font-weight: bold;
+  padding: 0.8rem 1.2rem;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+}

--- a/client-web/src/components/SearchBar/index.tsx
+++ b/client-web/src/components/SearchBar/index.tsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from "react";
+import useDebounce from "@hooks/useDebounce";
+import { searchAll } from "@services/searchApi";
+import styles from "./SearchBar.module.scss";
+
+interface Results {
+  messages: any[];
+  channels: any[];
+  files: any[];
+}
+
+const SearchBar: React.FC = () => {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Results>({
+    messages: [],
+    channels: [],
+    files: [],
+  });
+
+  const debounced = useDebounce(query, 300);
+
+  useEffect(() => {
+    if (!debounced.trim()) {
+      setResults({ messages: [], channels: [], files: [] });
+      return;
+    }
+    searchAll(debounced)
+      .then((data) => setResults(data))
+      .catch((e) => console.error(e));
+  }, [debounced]);
+
+  return (
+    <div className={styles["container"]}>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Recherche..."
+        className={styles["input"]}
+      />
+      {(results.messages.length || results.channels.length || results.files.length) && (
+        <ul className={styles["results"]}>
+          {results.messages.length > 0 && (
+            <>
+              <li className={styles["type-heading"]}>Messages</li>
+              {results.messages.map((m) => (
+                <li key={m._id} className={styles["result-item"]}>
+                  {(m.text || m.content || "").slice(0, 80)}
+                </li>
+              ))}
+            </>
+          )}
+          {results.files.length > 0 && (
+            <>
+              <li className={styles["type-heading"]}>Fichiers</li>
+              {results.files.map((f) => (
+                <li key={f._id} className={styles["result-item"]}>
+                  {f.originalName || f.filename}
+                </li>
+              ))}
+            </>
+          )}
+          {results.channels.length > 0 && (
+            <>
+              <li className={styles["type-heading"]}>Canaux</li>
+              {results.channels.map((c) => (
+                <li key={c._id} className={styles["result-item"]}>
+                  {c.name}
+                </li>
+              ))}
+            </>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/client-web/src/components/layout/Header/index.tsx
+++ b/client-web/src/components/layout/Header/index.tsx
@@ -81,6 +81,15 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme }) => {
             <span className={styles["notifBadge"]}>{unread}</span>
           )}
         </NavLink>
+        <NavLink
+          to="/search"
+          className={({ isActive }) =>
+            `${styles["navLink"]} ${isActive ? styles["active"] : ""}`
+          }
+          onClick={() => setMenuOpen(false)}
+        >
+          Recherche
+        </NavLink>
         {/* Logout button only visible in the hamburger menu on mobile */}
         <div className={styles["logoutMobile"]}>
           {user && (

--- a/client-web/src/hooks/useDebounce.ts
+++ b/client-web/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export default function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/client-web/src/pages/SearchPage/SearchPage.module.scss
+++ b/client-web/src/pages/SearchPage/SearchPage.module.scss
@@ -1,0 +1,4 @@
+.searchSection {
+  padding: 2.4rem;
+  margin-top: var(--header-height);
+}

--- a/client-web/src/pages/SearchPage/index.tsx
+++ b/client-web/src/pages/SearchPage/index.tsx
@@ -1,0 +1,13 @@
+import SearchBar from "@components/SearchBar";
+import styles from "./SearchPage.module.scss";
+
+const SearchPage: React.FC = () => {
+  return (
+    <section className={styles["searchSection"]}>
+      <h1>Recherche</h1>
+      <SearchBar />
+    </section>
+  );
+};
+
+export default SearchPage;

--- a/client-web/src/services/searchApi.ts
+++ b/client-web/src/services/searchApi.ts
@@ -1,0 +1,13 @@
+import api, { fetchCsrfToken } from "@utils/axiosInstance";
+
+export async function searchAll(query: string) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.get("/search", { params: { q: query } });
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message || err.message || "Erreur lors de la recherche"
+    );
+  }
+}

--- a/supchat-server/controllers/searchController.js
+++ b/supchat-server/controllers/searchController.js
@@ -1,0 +1,31 @@
+const Message = require("../models/Message");
+const Channel = require("../models/Channel");
+const FileMeta = require("../models/FileMeta");
+
+exports.search = async (req, res) => {
+  try {
+    const keywords = req.query.q;
+    if (!keywords || keywords.trim() === "") {
+      return res.status(400).json({ message: "Paramètre q requis" });
+    }
+
+    const query = { $text: { $search: keywords } };
+    const projection = { score: { $meta: "textScore" } };
+
+    const [messages, channels, files] = await Promise.all([
+      Message.find(query, projection)
+        .sort({ score: { $meta: "textScore" } })
+        .limit(20),
+      Channel.find(query, projection)
+        .sort({ score: { $meta: "textScore" } })
+        .limit(20),
+      FileMeta.find(query, projection)
+        .sort({ score: { $meta: "textScore" } })
+        .limit(20),
+    ]);
+
+    res.json({ messages, channels, files });
+  } catch (error) {
+    res.status(500).json({ message: "Erreur serveur", error });
+  }
+};

--- a/supchat-server/models/Channel.js
+++ b/supchat-server/models/Channel.js
@@ -2,10 +2,13 @@ const mongoose = require("mongoose");
 
 const ChannelSchema = new mongoose.Schema({
   name: String,
+  description: String,
   workspace: { type: mongoose.Schema.Types.ObjectId, ref: "Workspace" },
   type: { type: String, enum: ["public", "private"], required: true },
   members: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
   messages: [{ type: mongoose.Schema.Types.ObjectId, ref: "Message" }],
 });
+
+ChannelSchema.index({ name: "text", description: "text" });
 
 module.exports = mongoose.model("Channel", ChannelSchema);

--- a/supchat-server/models/FileMeta.js
+++ b/supchat-server/models/FileMeta.js
@@ -1,0 +1,15 @@
+const mongoose = require("mongoose");
+
+const FileMetaSchema = new mongoose.Schema({
+  filename: { type: String, required: true },
+  originalName: String,
+  mimetype: String,
+  size: Number,
+  channelId: { type: mongoose.Schema.Types.ObjectId, ref: "Channel" },
+  uploader: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+  createdAt: { type: Date, default: Date.now },
+});
+
+FileMetaSchema.index({ filename: "text", originalName: "text" });
+
+module.exports = mongoose.model("FileMeta", FileMetaSchema);

--- a/supchat-server/models/Message.js
+++ b/supchat-server/models/Message.js
@@ -1,11 +1,16 @@
 const mongoose = require("mongoose");
 
 const MessageSchema = new mongoose.Schema({
+  text: String,
   content: String,
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
   sender: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+  channelId: { type: mongoose.Schema.Types.ObjectId, ref: "Channel" },
   channel: { type: mongoose.Schema.Types.ObjectId, ref: "Channel" },
   createdAt: { type: Date, default: Date.now },
   file: String,
 });
+
+MessageSchema.index({ text: "text", content: "text" });
 
 module.exports = mongoose.model("Message", MessageSchema);

--- a/supchat-server/routes/index.js
+++ b/supchat-server/routes/index.js
@@ -7,6 +7,7 @@ const channelRoutes = require('./channel.Routes')
 const messageRoutes = require('./message.Routes')
 const permissionRoutes = require('./permission.Routes')
 const notificationRoutes = require('./notification.Routes')
+const searchRoutes = require('./search.Routes')
 
 router.use('/auth', authRoutes)
 router.use('/workspaces', workspaceRoutes)
@@ -14,5 +15,6 @@ router.use('/channels', channelRoutes)
 router.use('/messages', messageRoutes)
 router.use('/permissions', permissionRoutes)
 router.use('/notifications', notificationRoutes)
+router.use('/search', searchRoutes)
 
 module.exports = router

--- a/supchat-server/routes/search.Routes.js
+++ b/supchat-server/routes/search.Routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { search } = require('../controllers/searchController');
+
+const router = express.Router();
+
+router.get('/', search);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `/api/search` route with controller
- create FileMeta model for file metadata search
- extend Message and Channel schemas with text indexes
- add search API on client with debounced search bar
- include new Search page and nav link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d04c3aef48324adc94ee26d8ec9ef