### PR TITLE
Implement message file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ run-project.sh
 start-db.sh
 
 supchat-docs/
+supchat-server/uploads/

--- a/client-web/src/hooks/useMessages.ts
+++ b/client-web/src/hooks/useMessages.ts
@@ -16,9 +16,9 @@ export function useMessages(channelId: string) {
   const loading = useSelector((state: RootState) => state.messages.loading);
   const error = useSelector((state: RootState) => state.messages.error);
 
-  const send = async (text: string) => {
+  const send = async (text: string, file?: File | null) => {
     if (!channelId) return;
-    await dispatch(addMessage({ channelId, text }));
+    await dispatch(addMessage({ channelId, text, file }));
   };
 
   useEffect(() => {

--- a/client-web/src/pages/MessagesPage/index.tsx
+++ b/client-web/src/pages/MessagesPage/index.tsx
@@ -8,19 +8,28 @@ function MessagesPage() {
   const channelId = params.get("channel") || "";
   const { messages, loading, send } = useMessages(channelId);
   const [text, setText] = useState("");
+  const [file, setFile] = useState<File | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!text.trim()) return;
-    await send(text.trim());
+    if (!text.trim() && !file) return;
+    await send(text.trim(), file);
     setText("");
+    setFile(null);
   };
 
   return (
     <section className={styles["container"]}>
       <ul className={styles["list"]}>
         {messages.map((m: any) => (
-          <li key={m._id}>{m.text || m.content}</li>
+          <li key={m._id}>
+            {m.text || m.content}
+            {m.file && (
+              <a href={m.file} target="_blank" rel="noopener noreferrer">
+                {m.filename || "Fichier"}
+              </a>
+            )}
+          </li>
         ))}
       </ul>
       <form onSubmit={handleSubmit} className={styles["form"]}>
@@ -28,6 +37,11 @@ function MessagesPage() {
           type="text"
           value={text}
           onChange={(e) => setText(e.target.value)}
+          disabled={loading}
+        />
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
           disabled={loading}
         />
         <button type="submit" disabled={loading}>

--- a/client-web/src/services/messageApi.ts
+++ b/client-web/src/services/messageApi.ts
@@ -3,6 +3,7 @@ import api, { fetchCsrfToken } from "@utils/axiosInstance";
 export interface MessageFormData {
   channelId: string;
   text: string;
+  file?: File | null;
 }
 
 export async function getMessages(channelId: string) {
@@ -20,7 +21,13 @@ export async function getMessages(channelId: string) {
 export async function sendMessage(formData: MessageFormData) {
   try {
     await fetchCsrfToken();
-    const { data } = await api.post("/messages", formData);
+    const dataToSend = new FormData();
+    dataToSend.append("channelId", formData.channelId);
+    dataToSend.append("text", formData.text);
+    if (formData.file) dataToSend.append("file", formData.file);
+    const { data } = await api.post("/messages", dataToSend, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
     return data;
   } catch (err: any) {
     throw new Error(

--- a/supchat-server/controllers/messageController.js
+++ b/supchat-server/controllers/messageController.js
@@ -30,6 +30,13 @@ exports.sendMessage = async (req, res) => {
       text,
     });
 
+    if (req.file) {
+      message.file = `/uploads/${req.file.filename}`;
+      message.filename = req.file.originalname;
+      message.mimetype = req.file.mimetype;
+      message.size = req.file.size;
+    }
+
     await message.save();
     const io = getIo();
     try {

--- a/supchat-server/models/Message.js
+++ b/supchat-server/models/Message.js
@@ -9,6 +9,9 @@ const MessageSchema = new mongoose.Schema({
   channel: { type: mongoose.Schema.Types.ObjectId, ref: "Channel" },
   createdAt: { type: Date, default: Date.now },
   file: String,
+  filename: String,
+  mimetype: String,
+  size: Number,
 });
 
 MessageSchema.index({ text: "text", content: "text" });

--- a/supchat-server/routes/message.Routes.js
+++ b/supchat-server/routes/message.Routes.js
@@ -1,16 +1,29 @@
 const express = require("express");
+const multer = require("multer");
+const path = require("path");
 const {
   sendMessage,
   getMessagesByChannel,
   getMessageById,
   deleteMessage,
 } = require("../controllers/messageController");
+const { authMiddleware } = require("../middlewares/authMiddleware");
+
+const uploadDir = path.join(__dirname, "../uploads");
+const storage = multer.diskStorage({
+  destination: uploadDir,
+  filename: (req, file, cb) => {
+    const unique = Date.now() + "-" + Math.round(Math.random() * 1e9);
+    cb(null, `${unique}-${file.originalname}`);
+  },
+});
+const upload = multer({ storage });
 
 const router = express.Router();
 
-router.post("/", sendMessage);
-router.get("/channel/:channelId", getMessagesByChannel);
-router.get("/:id", getMessageById);
-router.delete("/:id", deleteMessage);
+router.post("/", authMiddleware, upload.single("file"), sendMessage);
+router.get("/channel/:channelId", authMiddleware, getMessagesByChannel);
+router.get("/:id", authMiddleware, getMessageById);
+router.delete("/:id", authMiddleware, deleteMessage);
 
 module.exports = router;

--- a/supchat-server/src/app.js
+++ b/supchat-server/src/app.js
@@ -10,6 +10,7 @@ const cors = require('cors')
 const helmet = require('helmet')
 const morgan = require('morgan')
 const cookieParser = require('cookie-parser')
+const path = require('path')
 
 dotenv.config()
 
@@ -47,6 +48,7 @@ app.use(morgan('dev'))
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 app.use(cookieParser())
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')))
 
 // ==== CLIENTID ==== //
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- allow message attachments via `multer`
- store uploaded files on disk and expose `/uploads` route
- add file metadata fields to `Message` model
- support attachments in web client

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d063c074c83248c45d39db75f16e5