### PR TITLE
Add user profile settings

### DIFF
--- a/client-web/src/App.tsx
+++ b/client-web/src/App.tsx
@@ -1,6 +1,6 @@
 // src/App.tsx
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect } from "react";
 import {
   BrowserRouter as Router,
   Routes,
@@ -11,6 +11,7 @@ import { useSelector } from "react-redux";
 import { RootState } from "@store/store.ts";
 import { useDispatch } from "react-redux";
 import { setAuth, logout, setAuthLoading } from "@store/authSlice";
+import { setTheme as setThemeAction } from "@store/preferencesSlice";
 import { getCurrentUser } from "@services/authApi";
 
 import styles from "./App.module.scss";
@@ -31,6 +32,7 @@ import ResetPasswordPage from "@pages/ResetPasswordPage";
 import WorkspaceDetailPage from "@pages/WorkspaceDetailPage";
 import InviteWorkspacePage from "@pages/InviteWorkspacePage";
 import SearchPage from "@pages/SearchPage";
+import SettingsPage from "@pages/SettingsPage";
 
 const AppContent = ({
   theme,
@@ -67,10 +69,11 @@ const AppContent = ({
           <Route element={<PrivateRoute />}>
             <Route path="/" element={<Dashboard />} />
             <Route path="/workspace" element={<WorkspacePage />} />
-          <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
-          <Route path="/message" element={<MessagesPage />} />
-          <Route path="/search" element={<SearchPage />} />
-        </Route>
+            <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
+            <Route path="/message" element={<MessagesPage />} />
+            <Route path="/search" element={<SearchPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Route>
         </Routes>
       </main>
 
@@ -80,28 +83,16 @@ const AppContent = ({
 };
 
 const App: React.FC = () => {
-  const [theme, setTheme] = useState<"light" | "dark">("light");
   const dispatch = useDispatch();
+  const theme = useSelector((state: RootState) => state.preferences.theme);
   const authLoading = useSelector((state: RootState) => state.auth.isLoading);
-  const authChecked = useRef(false);
 
-  // Retrieves the localStorage theme or prefers the system theme
+  // Initialise theme from store
   useEffect(() => {
-    if (authChecked.current) {
-      return;
-    }
-    authChecked.current = true;
-    const storedTheme = localStorage.getItem("theme") as
-      | "light"
-      | "dark"
-      | null;
-    const systemPrefersDark = window.matchMedia(
-      "(prefers-color-scheme: dark)"
-    ).matches;
-    const initialTheme = storedTheme || (systemPrefersDark ? "dark" : "light");
-    setTheme(initialTheme);
-    document.body.setAttribute("data-theme", initialTheme);
+    document.body.setAttribute("data-theme", theme);
+  }, [theme]);
 
+  useEffect(() => {
     dispatch(setAuthLoading(true));
     getCurrentUser()
       .then((user) => {
@@ -121,9 +112,8 @@ const App: React.FC = () => {
 
   const toggleTheme = () => {
     const newTheme = theme === "light" ? "dark" : "light";
-    setTheme(newTheme);
+    dispatch(setThemeAction(newTheme));
     document.body.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
   };
 
   return (

--- a/client-web/src/components/layout/Header/Header.module.scss
+++ b/client-web/src/components/layout/Header/Header.module.scss
@@ -159,6 +159,19 @@
       }
     }
 
+    .settingsLink {
+      color: var(--color-primary);
+      text-decoration: none;
+      margin-right: 0.6rem;
+      font-weight: 600;
+      &:hover {
+        color: var(--color-link);
+      }
+      @include mediaquery(md) {
+        margin-right: 0.6rem;
+      }
+    }
+
     .logoutBtn,
     .loginBtn {
       background: var(--color-primary);

--- a/client-web/src/components/layout/Header/index.tsx
+++ b/client-web/src/components/layout/Header/index.tsx
@@ -90,6 +90,15 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme }) => {
         >
           Recherche
         </NavLink>
+        <NavLink
+          to="/settings"
+          className={({ isActive }) =>
+            `${styles["navLink"]} ${isActive ? styles["active"] : ""}`
+          }
+          onClick={() => setMenuOpen(false)}
+        >
+          Paramètres
+        </NavLink>
         {/* Logout button only visible in the hamburger menu on mobile */}
         <div className={styles["logoutMobile"]}>
           {user && (
@@ -120,6 +129,9 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme }) => {
           <>
             {/* Username is only visible on desktop */}
             <span className={styles["username"]}>{user.name}</span>
+            <NavLink to="/settings" className={styles["settingsLink"]}>
+              Paramètres
+            </NavLink>
             <button
               className={styles["logoutBtn"] + " " + styles["logoutDesktop"]}
               onClick={handleLogout}

--- a/client-web/src/pages/SettingsPage/SettingsPage.module.scss
+++ b/client-web/src/pages/SettingsPage/SettingsPage.module.scss
@@ -1,0 +1,15 @@
+.settingsPage {
+  padding: 2rem;
+}
+
+.profileSection,
+.prefSection {
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+button {
+  width: fit-content;
+}

--- a/client-web/src/pages/SettingsPage/index.tsx
+++ b/client-web/src/pages/SettingsPage/index.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import type { RootState, AppDispatch } from '@store/store'
+import {
+  setTheme,
+  setStatus,
+  Theme,
+  Status,
+} from '@store/preferencesSlice'
+import {
+  getProfile,
+  updateProfile,
+  getPreferences,
+  updatePreferences,
+} from '@services/userApi'
+import styles from './SettingsPage.module.scss'
+
+const SettingsPage: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const { theme, status } = useSelector((state: RootState) => state.preferences)
+  const user = useSelector((state: RootState) => state.auth.user)
+  const [name, setName] = useState('')
+  const [avatar, setAvatar] = useState('')
+
+  useEffect(() => {
+    getProfile().then((u) => {
+      setName(u.name)
+      setAvatar(u.avatar || '')
+    })
+    getPreferences().then((p) => {
+      dispatch(setTheme(p.theme as Theme))
+      dispatch(setStatus(p.status as Status))
+    })
+  }, [dispatch])
+
+  const handleSaveProfile = async () => {
+    await updateProfile({ name, avatar })
+  }
+
+  const handleThemeToggle = async () => {
+    const newTheme: Theme = theme === 'light' ? 'dark' : 'light'
+    dispatch(setTheme(newTheme))
+    await updatePreferences({ theme: newTheme })
+    document.body.setAttribute('data-theme', newTheme)
+  }
+
+  const handleStatusChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newStatus = e.target.value as Status
+    dispatch(setStatus(newStatus))
+    await updatePreferences({ status: newStatus })
+  }
+
+  if (!user) return null
+
+  return (
+    <section className={styles.settingsPage}>
+      <h1>Paramètres</h1>
+      <div className={styles.profileSection}>
+        <label>
+          Nom affiché
+          <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <label>
+          Avatar URL
+          <input value={avatar} onChange={(e) => setAvatar(e.target.value)} />
+        </label>
+        <button onClick={handleSaveProfile}>Sauvegarder</button>
+      </div>
+      <div className={styles.prefSection}>
+        <button onClick={handleThemeToggle}>
+          Thème : {theme === 'light' ? 'Clair' : 'Sombre'}
+        </button>
+        <label>
+          Statut
+          <select value={status} onChange={handleStatusChange}>
+            <option value="online">En ligne</option>
+            <option value="away">Absent</option>
+            <option value="busy">Occupé</option>
+            <option value="offline">Hors ligne</option>
+          </select>
+        </label>
+      </div>
+    </section>
+  )
+}
+
+export default SettingsPage

--- a/client-web/src/services/userApi.ts
+++ b/client-web/src/services/userApi.ts
@@ -1,0 +1,28 @@
+import api, { fetchCsrfToken } from '@utils/axiosInstance'
+
+export async function getProfile() {
+  const { data } = await api.get('/user/profile')
+  return data
+}
+
+export async function updateProfile(data: { name?: string; avatar?: string }) {
+  await fetchCsrfToken()
+  const res = await api.put('/user/profile', data)
+  return res.data
+}
+
+export async function getPreferences() {
+  const { data } = await api.get('/user/preferences')
+  return data
+}
+
+export async function updatePreferences(data: { theme?: string; status?: string }) {
+  await fetchCsrfToken()
+  const res = await api.put('/user/preferences', data)
+  return res.data
+}
+
+export async function exportUserData() {
+  const { data } = await api.get('/user/export')
+  return data
+}

--- a/client-web/src/store/preferencesSlice.ts
+++ b/client-web/src/store/preferencesSlice.ts
@@ -1,0 +1,42 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+export type Theme = 'light' | 'dark'
+export type Status = 'online' | 'away' | 'busy' | 'offline'
+
+interface PreferencesState {
+  theme: Theme
+  status: Status
+}
+
+const initialState: PreferencesState = {
+  theme: (localStorage.getItem('theme') as Theme) || 'light',
+  status: (localStorage.getItem('status') as Status) || 'online',
+}
+
+const preferencesSlice = createSlice({
+  name: 'preferences',
+  initialState,
+  reducers: {
+    setTheme(state, action: PayloadAction<Theme>) {
+      state.theme = action.payload
+      localStorage.setItem('theme', action.payload)
+    },
+    setStatus(state, action: PayloadAction<Status>) {
+      state.status = action.payload
+      localStorage.setItem('status', action.payload)
+    },
+    setPreferences(state, action: PayloadAction<Partial<PreferencesState>>) {
+      if (action.payload.theme) {
+        state.theme = action.payload.theme
+        localStorage.setItem('theme', action.payload.theme)
+      }
+      if (action.payload.status) {
+        state.status = action.payload.status
+        localStorage.setItem('status', action.payload.status)
+      }
+    },
+  },
+})
+
+export const { setTheme, setStatus, setPreferences } = preferencesSlice.actions
+export default preferencesSlice.reducer

--- a/client-web/src/store/store.ts
+++ b/client-web/src/store/store.ts
@@ -6,6 +6,7 @@ import workspacesReducer from "@store/workspacesSlice";
 import channelsReducer from "@store/channelsSlice";
 import messagesReducer from "@store/messagesSlice";
 import notificationsReducer from "@store/notificationsSlice";
+import preferencesReducer from "@store/preferencesSlice";
 
 export const store = configureStore({
   reducer: {
@@ -14,6 +15,7 @@ export const store = configureStore({
     channels: channelsReducer,
     messages: messagesReducer,
     notifications: notificationsReducer,
+    preferences: preferencesReducer,
   },
 });
 

--- a/supchat-server/controllers/userController.js
+++ b/supchat-server/controllers/userController.js
@@ -1,0 +1,51 @@
+const userService = require('../services/userService')
+
+exports.getProfile = async (req, res) => {
+    try {
+        const user = await userService.getById(req.user.id)
+        if (!user) return res.status(404).json({ message: 'Utilisateur non trouvé' })
+        res.json(user)
+    } catch (error) {
+        res.status(500).json({ message: 'Erreur serveur', error })
+    }
+}
+
+exports.updateProfile = async (req, res) => {
+    try {
+        const user = await userService.updateProfile(req.user.id, req.body)
+        if (!user) return res.status(404).json({ message: 'Utilisateur non trouvé' })
+        res.json(user)
+    } catch (error) {
+        res.status(500).json({ message: 'Erreur serveur', error })
+    }
+}
+
+exports.getPreferences = async (req, res) => {
+    try {
+        const user = await userService.getById(req.user.id)
+        if (!user) return res.status(404).json({ message: 'Utilisateur non trouvé' })
+        res.json({ theme: user.theme, status: user.status })
+    } catch (error) {
+        res.status(500).json({ message: 'Erreur serveur', error })
+    }
+}
+
+exports.updatePreferences = async (req, res) => {
+    try {
+        const user = await userService.updatePreferences(req.user.id, req.body)
+        if (!user) return res.status(404).json({ message: 'Utilisateur non trouvé' })
+        res.json({ theme: user.theme, status: user.status })
+    } catch (error) {
+        res.status(500).json({ message: 'Erreur serveur', error })
+    }
+}
+
+exports.exportUserData = async (req, res) => {
+    try {
+        const data = await userService.exportData(req.user.id)
+        if (!data) return res.status(404).json({ message: 'Utilisateur non trouvé' })
+        res.json(data)
+    } catch (error) {
+        res.status(500).json({ message: 'Erreur serveur', error })
+    }
+}

--- a/supchat-server/models/User.js
+++ b/supchat-server/models/User.js
@@ -10,6 +10,16 @@ const UserSchema = new mongoose.Schema({
     },
     password: String,
     avatar: String,
+    theme: {
+        type: String,
+        enum: ['light', 'dark'],
+        default: 'light',
+    },
+    status: {
+        type: String,
+        enum: ['online', 'away', 'busy', 'offline'],
+        default: 'online',
+    },
     googleId: String,
     facebookId: String,
     resetPasswordToken: { type: String },

--- a/supchat-server/routes/index.js
+++ b/supchat-server/routes/index.js
@@ -8,6 +8,7 @@ const messageRoutes = require('./message.Routes')
 const permissionRoutes = require('./permission.Routes')
 const notificationRoutes = require('./notification.Routes')
 const searchRoutes = require('./search.Routes')
+const userRoutes = require('./user.Routes')
 
 router.use('/auth', authRoutes)
 router.use('/workspaces', workspaceRoutes)
@@ -16,5 +17,6 @@ router.use('/messages', messageRoutes)
 router.use('/permissions', permissionRoutes)
 router.use('/notifications', notificationRoutes)
 router.use('/search', searchRoutes)
+router.use('/user', userRoutes)
 
 module.exports = router

--- a/supchat-server/routes/user.Routes.js
+++ b/supchat-server/routes/user.Routes.js
@@ -1,0 +1,30 @@
+const express = require('express')
+const userController = require('../controllers/userController')
+const { authMiddleware } = require('../middlewares/authMiddleware')
+const { validate } = require('../middlewares/validationMiddleware')
+const {
+    updateProfileSchema,
+    updatePreferencesSchema,
+} = require('../validators/userValidators')
+
+const router = express.Router()
+
+router.get('/profile', authMiddleware, userController.getProfile)
+router.put(
+    '/profile',
+    authMiddleware,
+    validate({ body: updateProfileSchema }),
+    userController.updateProfile
+)
+
+router.get('/preferences', authMiddleware, userController.getPreferences)
+router.put(
+    '/preferences',
+    authMiddleware,
+    validate({ body: updatePreferencesSchema }),
+    userController.updatePreferences
+)
+
+router.get('/export', authMiddleware, userController.exportUserData)
+
+module.exports = router

--- a/supchat-server/services/userService.js
+++ b/supchat-server/services/userService.js
@@ -1,0 +1,39 @@
+const User = require('../models/User')
+
+const getById = (id) => {
+    return User.findById(id).select('-password -resetPasswordToken -resetPasswordExpires')
+}
+
+const updateProfile = async (id, { name, avatar }) => {
+    const user = await User.findById(id)
+    if (!user) return null
+    if (name !== undefined) user.name = name
+    if (avatar !== undefined) user.avatar = avatar
+    await user.save()
+    return user
+}
+
+const updatePreferences = async (id, { theme, status }) => {
+    const user = await User.findById(id)
+    if (!user) return null
+    if (theme !== undefined) user.theme = theme
+    if (status !== undefined) user.status = status
+    await user.save()
+    return user
+}
+
+const exportData = async (id) => {
+    const user = await User.findById(id).lean()
+    if (!user) return null
+    delete user.password
+    delete user.resetPasswordToken
+    delete user.resetPasswordExpires
+    return user
+}
+
+module.exports = {
+    getById,
+    updateProfile,
+    updatePreferences,
+    exportData,
+}

--- a/supchat-server/validators/userValidators.js
+++ b/supchat-server/validators/userValidators.js
@@ -1,0 +1,16 @@
+const Joi = require('joi')
+
+const updateProfileSchema = Joi.object({
+    name: Joi.string().min(1).max(50),
+    avatar: Joi.string().uri(),
+}).min(1)
+
+const updatePreferencesSchema = Joi.object({
+    theme: Joi.string().valid('light', 'dark'),
+    status: Joi.string().valid('online', 'away', 'busy', 'offline'),
+}).min(1)
+
+module.exports = {
+    updateProfileSchema,
+    updatePreferencesSchema,
+}


### PR DESCRIPTION
## Summary
- extend user model with theme and status fields
- add user profile and preference endpoints
- create user service and controller
- allow exporting profile data
- manage preferences with Redux
- add settings page with theme toggle and status selector
- update header navigation and store setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d079f84dc8324ae6d0a9999eecb5e