### PR TITLE
Add drive/github integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,17 @@ GMAIL_PASS=ton_mot_de_passe_application
 # Google OAuth credentials  
 GOOGLE_CLIENT_ID=your_google_client_id_here  
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here  
-GOOGLE_REDIRECT_URI=http://localhost:5000/api/auth/google/callback  
+GOOGLE_REDIRECT_URI=http://localhost:5000/api/auth/google/callback
+
+# Google Drive OAuth
+GDRIVE_CLIENT_ID=your_google_drive_client_id
+GDRIVE_CLIENT_SECRET=your_google_drive_client_secret
+GDRIVE_REDIRECT_URI=http://localhost:3000/api/integrations/google-drive/callback
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret
+GITHUB_REDIRECT_URI=http://localhost:3000/api/integrations/github/callback
 
 # Facebook OAuth credentials
 FACEBOOK_APP_ID=your_facebook_client_id

--- a/client-web/src/pages/SettingsPage/SettingsPage.module.scss
+++ b/client-web/src/pages/SettingsPage/SettingsPage.module.scss
@@ -10,6 +10,13 @@
   gap: 1rem;
 }
 
+.integrationSection {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 button {
   width: fit-content;
 }

--- a/client-web/src/pages/SettingsPage/index.tsx
+++ b/client-web/src/pages/SettingsPage/index.tsx
@@ -13,6 +13,13 @@ import {
   getPreferences,
   updatePreferences,
 } from '@services/userApi'
+import {
+  listIntegrations,
+  linkGoogleDrive,
+  unlinkGoogleDrive,
+  linkGithub,
+  unlinkGithub,
+} from '@services/integrationApi'
 import styles from './SettingsPage.module.scss'
 
 const SettingsPage: React.FC = () => {
@@ -21,6 +28,10 @@ const SettingsPage: React.FC = () => {
   const user = useSelector((state: RootState) => state.auth.user)
   const [name, setName] = useState('')
   const [avatar, setAvatar] = useState('')
+  const [integrations, setIntegrations] = useState({
+    googleDrive: false,
+    github: false,
+  })
 
   useEffect(() => {
     getProfile().then((u) => {
@@ -31,6 +42,7 @@ const SettingsPage: React.FC = () => {
       dispatch(setTheme(p.theme as Theme))
       dispatch(setStatus(p.status as Status))
     })
+    listIntegrations().then(setIntegrations)
   }, [dispatch])
 
   const handleSaveProfile = async () => {
@@ -48,6 +60,32 @@ const SettingsPage: React.FC = () => {
     const newStatus = e.target.value as Status
     dispatch(setStatus(newStatus))
     await updatePreferences({ status: newStatus })
+  }
+
+  const handleLinkDrive = async () => {
+    const code = prompt('Code Google OAuth')
+    if (code) {
+      await linkGoogleDrive(code)
+      setIntegrations({ ...integrations, googleDrive: true })
+    }
+  }
+
+  const handleUnlinkDrive = async () => {
+    await unlinkGoogleDrive()
+    setIntegrations({ ...integrations, googleDrive: false })
+  }
+
+  const handleLinkGithub = async () => {
+    const token = prompt('GitHub token')
+    if (token) {
+      await linkGithub(token)
+      setIntegrations({ ...integrations, github: true })
+    }
+  }
+
+  const handleUnlinkGithub = async () => {
+    await unlinkGithub()
+    setIntegrations({ ...integrations, github: false })
   }
 
   if (!user) return null
@@ -79,6 +117,25 @@ const SettingsPage: React.FC = () => {
             <option value="offline">Hors ligne</option>
           </select>
         </label>
+      </div>
+      <div className={styles.integrationSection}>
+        <h2>Intégrations</h2>
+        <div>
+          <span>Google Drive: {integrations.googleDrive ? 'connecté' : 'déconnecté'}</span>
+          {integrations.googleDrive ? (
+            <button onClick={handleUnlinkDrive}>Déconnecter</button>
+          ) : (
+            <button onClick={handleLinkDrive}>Connecter</button>
+          )}
+        </div>
+        <div>
+          <span>GitHub: {integrations.github ? 'connecté' : 'déconnecté'}</span>
+          {integrations.github ? (
+            <button onClick={handleUnlinkGithub}>Déconnecter</button>
+          ) : (
+            <button onClick={handleLinkGithub}>Connecter</button>
+          )}
+        </div>
       </div>
     </section>
   )

--- a/client-web/src/services/integrationApi.ts
+++ b/client-web/src/services/integrationApi.ts
@@ -1,0 +1,28 @@
+import api, { fetchCsrfToken } from "@utils/axiosInstance"
+
+export async function listIntegrations() {
+  const { data } = await api.get("/integrations")
+  return data as { googleDrive: boolean; github: boolean }
+}
+
+export async function linkGoogleDrive(code: string) {
+  await fetchCsrfToken()
+  const { data } = await api.post("/integrations/google-drive", { code })
+  return data
+}
+
+export async function unlinkGoogleDrive() {
+  await fetchCsrfToken()
+  await api.delete("/integrations/google-drive")
+}
+
+export async function linkGithub(token: string) {
+  await fetchCsrfToken()
+  const { data } = await api.post("/integrations/github", { token })
+  return data
+}
+
+export async function unlinkGithub() {
+  await fetchCsrfToken()
+  await api.delete("/integrations/github")
+}

--- a/supchat-server/controllers/integrationController.js
+++ b/supchat-server/controllers/integrationController.js
@@ -1,0 +1,61 @@
+const { google } = require("googleapis")
+const { Octokit } = require("@octokit/rest")
+const integrationService = require("../services/integrationService")
+
+const driveScopes = ["https://www.googleapis.com/auth/drive.file"]
+
+const driveClient = new google.auth.OAuth2(
+  process.env.GDRIVE_CLIENT_ID,
+  process.env.GDRIVE_CLIENT_SECRET,
+  process.env.GDRIVE_REDIRECT_URI
+)
+
+exports.linkGoogleDrive = async (req, res) => {
+  try {
+    const { code } = req.body
+    const { tokens } = await driveClient.getToken(code)
+    await integrationService.setGoogleDrive(req.user.id, tokens)
+    res.status(200).json({ message: "Google Drive linked" })
+  } catch (error) {
+    res.status(500).json({ message: "Failed to link Google Drive", error })
+  }
+}
+
+exports.unlinkGoogleDrive = async (req, res) => {
+  try {
+    await integrationService.removeGoogleDrive(req.user.id)
+    res.status(200).json({ message: "Google Drive unlinked" })
+  } catch (error) {
+    res.status(500).json({ message: "Failed to unlink Google Drive", error })
+  }
+}
+
+exports.linkGithub = async (req, res) => {
+  try {
+    const { token } = req.body
+    const octokit = new Octokit({ auth: token })
+    await octokit.request("GET /user")
+    await integrationService.setGithub(req.user.id, token)
+    res.status(200).json({ message: "GitHub linked" })
+  } catch (error) {
+    res.status(500).json({ message: "Failed to link GitHub", error })
+  }
+}
+
+exports.unlinkGithub = async (req, res) => {
+  try {
+    await integrationService.removeGithub(req.user.id)
+    res.status(200).json({ message: "GitHub unlinked" })
+  } catch (error) {
+    res.status(500).json({ message: "Failed to unlink GitHub", error })
+  }
+}
+
+exports.listIntegrations = async (req, res) => {
+  try {
+    const integrations = await integrationService.getIntegrations(req.user.id)
+    res.json(integrations)
+  } catch (error) {
+    res.status(500).json({ message: "Failed to load integrations", error })
+  }
+}

--- a/supchat-server/models/User.js
+++ b/supchat-server/models/User.js
@@ -22,6 +22,11 @@ const UserSchema = new mongoose.Schema({
     },
     googleId: String,
     facebookId: String,
+    googleDrive: {
+        accessToken: String,
+        refreshToken: String,
+    },
+    githubToken: String,
     resetPasswordToken: { type: String },
     resetPasswordExpires: { type: Date },
 })

--- a/supchat-server/package.json
+++ b/supchat-server/package.json
@@ -24,6 +24,8 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "google-auth-library": "^9.15.1",
+    "googleapis": "^131.0.0",
+    "@octokit/rest": "^20.0.0",
     "helmet": "^8.0.0",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",

--- a/supchat-server/routes/index.js
+++ b/supchat-server/routes/index.js
@@ -9,6 +9,7 @@ const permissionRoutes = require('./permission.Routes')
 const notificationRoutes = require('./notification.Routes')
 const searchRoutes = require('./search.Routes')
 const userRoutes = require('./user.Routes')
+const integrationRoutes = require('./integration.Routes')
 
 router.use('/auth', authRoutes)
 router.use('/workspaces', workspaceRoutes)
@@ -18,5 +19,6 @@ router.use('/permissions', permissionRoutes)
 router.use('/notifications', notificationRoutes)
 router.use('/search', searchRoutes)
 router.use('/user', userRoutes)
+router.use('/integrations', integrationRoutes)
 
 module.exports = router

--- a/supchat-server/routes/integration.Routes.js
+++ b/supchat-server/routes/integration.Routes.js
@@ -1,0 +1,19 @@
+const express = require("express")
+const { authMiddleware } = require("../middlewares/authMiddleware")
+const {
+  linkGoogleDrive,
+  unlinkGoogleDrive,
+  linkGithub,
+  unlinkGithub,
+  listIntegrations,
+} = require("../controllers/integrationController")
+
+const router = express.Router()
+
+router.get("/", authMiddleware, listIntegrations)
+router.post("/google-drive", authMiddleware, linkGoogleDrive)
+router.delete("/google-drive", authMiddleware, unlinkGoogleDrive)
+router.post("/github", authMiddleware, linkGithub)
+router.delete("/github", authMiddleware, unlinkGithub)
+
+module.exports = router

--- a/supchat-server/services/integrationService.js
+++ b/supchat-server/services/integrationService.js
@@ -1,0 +1,54 @@
+const User = require("../models/User")
+
+const getIntegrations = async (userId) => {
+  const user = await User.findById(userId).select(
+    "googleDrive githubToken"
+  )
+  return {
+    googleDrive: !!(user && user.googleDrive && user.googleDrive.accessToken),
+    github: !!(user && user.githubToken),
+  }
+}
+
+const setGoogleDrive = async (userId, tokens) => {
+  const user = await User.findById(userId)
+  if (!user) return null
+  user.googleDrive = {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+  }
+  await user.save()
+  return user
+}
+
+const removeGoogleDrive = async (userId) => {
+  const user = await User.findById(userId)
+  if (!user) return null
+  user.googleDrive = undefined
+  await user.save()
+  return user
+}
+
+const setGithub = async (userId, token) => {
+  const user = await User.findById(userId)
+  if (!user) return null
+  user.githubToken = token
+  await user.save()
+  return user
+}
+
+const removeGithub = async (userId) => {
+  const user = await User.findById(userId)
+  if (!user) return null
+  user.githubToken = undefined
+  await user.save()
+  return user
+}
+
+module.exports = {
+  getIntegrations,
+  setGoogleDrive,
+  removeGoogleDrive,
+  setGithub,
+  removeGithub,
+}


### PR DESCRIPTION
## Summary
- add OAuth example credentials for Drive and GitHub
- support Drive and GitHub tokens in user model
- create integration service, controller and routes
- expose integration API on the web client
- extend settings page with connect/disconnect buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d09b3588c832482b09db5fd51c001