### PR TITLE
Add channel roles support

### DIFF
--- a/client-web/src/components/Permissions/RoleSelector/index.tsx
+++ b/client-web/src/components/Permissions/RoleSelector/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface RoleSelectorProps {
+  value: string;
+  onChange: (role: string) => void;
+}
+
+const RoleSelector: React.FC<RoleSelectorProps> = ({ value, onChange }) => {
+  return (
+    <select value={value} onChange={(e) => onChange(e.target.value)}>
+      <option value="admin">admin</option>
+      <option value="membre">membre</option>
+      <option value="invité">invité</option>
+    </select>
+  );
+};
+
+export default RoleSelector;
+

--- a/client-web/src/hooks/usePermissions.ts
+++ b/client-web/src/hooks/usePermissions.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { getWorkspacePermissions, updatePermission } from "@services/permissionApi";
+
+export interface Permission {
+  _id: string;
+  userId: { _id: string; email?: string; username?: string };
+  role: string;
+  channelRoles: { channelId: string; role: string }[];
+}
+
+export function usePermissions(workspaceId: string) {
+  const [permissions, setPermissions] = useState<Permission[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = async () => {
+    if (!workspaceId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getWorkspacePermissions(workspaceId);
+      setPermissions(data);
+    } catch (err: any) {
+      setError(err.message || "Erreur lors du chargement");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const setRole = async (
+    permissionId: string,
+    payload: { role?: string; channelRoles?: any[] }
+  ) => {
+    await updatePermission(permissionId, payload);
+    fetchAll();
+  };
+
+  useEffect(() => {
+    fetchAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId]);
+
+  return { permissions, loading, error, fetchPermissions: fetchAll, setRole };
+}
+

--- a/client-web/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.module.scss
+++ b/client-web/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.module.scss
@@ -124,3 +124,11 @@
   font-size: 1.1rem;
   text-align: center;
 }
+
+.channelRole {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+

--- a/client-web/src/services/permissionApi.ts
+++ b/client-web/src/services/permissionApi.ts
@@ -1,0 +1,17 @@
+import api, { fetchCsrfToken } from "@utils/axiosInstance";
+
+export async function getWorkspacePermissions(workspaceId: string) {
+  await fetchCsrfToken();
+  const { data } = await api.get("/permissions", { params: { workspaceId } });
+  return data;
+}
+
+export async function updatePermission(
+  permissionId: string,
+  payload: { role?: string; channelRoles?: any[] }
+) {
+  await fetchCsrfToken();
+  const { data } = await api.put(`/permissions/${permissionId}`, payload);
+  return data;
+}
+

--- a/supchat-server/models/Permission.js
+++ b/supchat-server/models/Permission.js
@@ -17,6 +17,20 @@ const PermissionSchema = new mongoose.Schema(
       enum: ["admin", "membre", "invité"],
       default: "membre",
     },
+    channelRoles: [
+      {
+        channelId: {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: "Channel",
+          required: true,
+        },
+        role: {
+          type: String,
+          enum: ["admin", "membre", "invité"],
+          default: "membre",
+        },
+      },
+    ],
     permissions: {
       canPost: { type: Boolean, default: true },
       canDeleteMessages: { type: Boolean, default: false },


### PR DESCRIPTION
## Summary
- extend Permission model with channelRoles
- filter permissions by workspace
- enforce channel and workspace roles when posting messages
- allow channel admins to manage channels
- expose permission API in web client
- add role management UI in workspace detail page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d0b068fe083249a9421eee40c3ac3