### PR TITLE
Improve messaging, dashboard and management UI

### DIFF
--- a/client-web/src/components/Channel/ChannelList/index.tsx
+++ b/client-web/src/components/Channel/ChannelList/index.tsx
@@ -10,17 +10,27 @@ export type Channel = {
 
 interface ChannelListProps {
   channels: Channel[];
+  filter?: string;
   onAccess?: (channel: Channel) => void;
 }
 
-const ChannelList: React.FC<ChannelListProps> = ({ channels, onAccess }) => {
-  if (!channels.length) {
+const ChannelList: React.FC<ChannelListProps> = ({ channels, filter, onAccess }) => {
+  const lowered = filter ? filter.toLowerCase() : "";
+  const filtered = lowered
+    ? channels.filter(
+        (c) =>
+          c.name.toLowerCase().includes(lowered) ||
+          (c.description || "").toLowerCase().includes(lowered)
+      )
+    : channels;
+
+  if (!filtered.length) {
     return <p>Aucun canal pour le moment.</p>;
   }
 
   return (
     <ul className={styles["channel-list"]}>
-      {channels.map((ch) => (
+      {filtered.map((ch) => (
         <li key={ch._id} className={styles["channel-item"]}>
           <div className={styles["channel-header"]}>
             <strong>{ch.name}</strong>

--- a/client-web/src/components/Message/MessageItem/MessageItem.module.scss
+++ b/client-web/src/components/Message/MessageItem/MessageItem.module.scss
@@ -1,0 +1,34 @@
+.item {
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.meta {
+  display: flex;
+  gap: 0.8rem;
+  font-size: 1.2rem;
+  color: var(--color-text-secondary);
+}
+
+.author {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.text {
+  font-size: 1.4rem;
+}
+
+.image {
+  max-width: 20rem;
+  max-height: 20rem;
+  border-radius: 0.4rem;
+}
+
+.file {
+  color: var(--color-link);
+  word-break: break-all;
+}

--- a/client-web/src/components/Message/MessageItem/index.tsx
+++ b/client-web/src/components/Message/MessageItem/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styles from "./MessageItem.module.scss";
+
+interface MessageItemProps {
+  message: any;
+}
+
+const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
+  const isImage = message.mimetype && message.mimetype.startsWith("image/");
+  return (
+    <li className={styles["item"]}>
+      <div className={styles["meta"]}>
+        <span className={styles["author"]}>
+          {message.userId?.username || message.userId?.email || "Utilisateur"}
+        </span>
+        <span className={styles["time"]}>
+          {new Date(message.createdAt).toLocaleString()}
+        </span>
+      </div>
+      {message.text && <p className={styles["text"]}>{message.text}</p>}
+      {isImage ? (
+        <img
+          src={message.file}
+          alt={message.filename || ""}
+          className={styles["image"]}
+        />
+      ) : (
+        message.file && (
+          <a
+            href={message.file}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles["file"]}
+          >
+            {message.filename || "Fichier"}
+          </a>
+        )
+      )}
+    </li>
+  );
+};
+
+export default MessageItem;

--- a/client-web/src/components/Notification/NotificationList/NotificationList.module.scss
+++ b/client-web/src/components/Notification/NotificationList/NotificationList.module.scss
@@ -1,0 +1,26 @@
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-bg-card);
+}
+
+.unread {
+  background: var(--color-bg-secondary);
+}
+
+.text {
+  font-size: 1.4rem;
+}

--- a/client-web/src/components/Notification/NotificationList/index.tsx
+++ b/client-web/src/components/Notification/NotificationList/index.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import styles from "./NotificationList.module.scss";
+
+interface NotificationListProps {
+  items: any[];
+  onRead?: (id: string) => void;
+}
+
+const NotificationList: React.FC<NotificationListProps> = ({ items, onRead }) => {
+  if (!items.length) {
+    return <p>Aucune notification.</p>;
+  }
+
+  return (
+    <ul className={styles["list"]}>
+      {items.map((n) => (
+        <li
+          key={n._id}
+          className={`${styles["item"]} ${!n.read ? styles["unread"] : ""}`}
+        >
+          <span className={styles["text"]}>
+            {(n.messageId?.text || "Nouvelle activité").slice(0, 80)}
+          </span>
+          {!n.read && onRead && (
+            <button
+              type="button"
+              className="btn"
+              onClick={() => onRead(n._id)}
+            >
+              Marquer comme lu
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default NotificationList;

--- a/client-web/src/components/Workspace/WorkspaceList/index.tsx
+++ b/client-web/src/components/Workspace/WorkspaceList/index.tsx
@@ -13,6 +13,7 @@ type Workspace = {
 type WorkspaceListProps = {
   workspaces: Workspace[];
   user?: { email?: string; role?: string; _id?: string } | undefined;
+  filter?: string;
   onAccess?: (workspace: Workspace) => void;
   onInvite?: (workspace: Workspace) => void;
   onEdit?: (workspace: Workspace) => void;
@@ -22,18 +23,28 @@ type WorkspaceListProps = {
 const WorkspaceList: React.FC<WorkspaceListProps> = ({
   workspaces,
   user,
+  filter,
   onAccess,
   onInvite,
   onEdit,
   onDelete,
 }) => {
-  if (!workspaces.length) {
+  const lowered = filter ? filter.toLowerCase() : "";
+  const filtered = lowered
+    ? workspaces.filter(
+        (w) =>
+          w.name.toLowerCase().includes(lowered) ||
+          (w.description || "").toLowerCase().includes(lowered)
+      )
+    : workspaces;
+
+  if (!filtered.length) {
     return <p>Aucun espace de travail pour le moment.</p>;
   }
 
   return (
     <ul className={styles["workspace-list"]}>
-      {workspaces.map((ws) => {
+      {filtered.map((ws) => {
         const isOwner =
           user &&
           ws.owner &&

--- a/client-web/src/pages/Dashboard/Dashboard.module.scss
+++ b/client-web/src/pages/Dashboard/Dashboard.module.scss
@@ -1,1 +1,14 @@
-// src/pages/Dashboard/Dashboard.module.scss
+.container {
+  padding: 2rem;
+  max-width: 60rem;
+  margin: 0 auto;
+}
+
+.title {
+  margin-bottom: 2rem;
+}
+
+.subtitle {
+  margin-bottom: 1rem;
+  font-size: 1.6rem;
+}

--- a/client-web/src/pages/Dashboard/index.tsx
+++ b/client-web/src/pages/Dashboard/index.tsx
@@ -1,9 +1,20 @@
 // src/pages/Dashboard/Dashboard.tsx
 
-// import styles from './Dashboard.module.scss'
+import styles from "./Dashboard.module.scss";
+import { useNotifications } from "@hooks/useNotifications";
+import NotificationList from "@components/Notification/NotificationList";
 
 function Dashboard() {
-  return <h1>Tableau de bord</h1>;
+  const { notifications, unread, markAsRead } = useNotifications();
+  return (
+    <section className={styles["container"]}>
+      <h1 className={styles["title"]}>Tableau de bord</h1>
+      <h2 className={styles["subtitle"]}>
+        Notifications {unread > 0 && <span>({unread})</span>}
+      </h2>
+      <NotificationList items={notifications} onRead={markAsRead} />
+    </section>
+  );
 }
 
 export default Dashboard;

--- a/client-web/src/pages/MessagesPage/MessagesPage.module.scss
+++ b/client-web/src/pages/MessagesPage/MessagesPage.module.scss
@@ -1,14 +1,19 @@
 .container {
   padding: 1rem;
+  max-width: 60rem;
+  margin: 0 auto;
 }
 
 .list {
   list-style: none;
   padding: 0;
   margin: 0 0 1rem 0;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .form {
   display: flex;
   gap: 0.5rem;
+  margin-top: 1rem;
 }

--- a/client-web/src/pages/MessagesPage/index.tsx
+++ b/client-web/src/pages/MessagesPage/index.tsx
@@ -1,7 +1,8 @@
 import { useSearchParams } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useMessages } from "@hooks/useMessages";
 import styles from "./MessagesPage.module.scss";
+import MessageItem from "@components/Message/MessageItem";
 
 function MessagesPage() {
   const [params] = useSearchParams();
@@ -9,6 +10,7 @@ function MessagesPage() {
   const { messages, loading, send } = useMessages(channelId);
   const [text, setText] = useState("");
   const [file, setFile] = useState<File | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -18,18 +20,17 @@ function MessagesPage() {
     setFile(null);
   };
 
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [messages]);
+
   return (
     <section className={styles["container"]}>
-      <ul className={styles["list"]}>
+      <ul ref={listRef} className={styles["list"]}>
         {messages.map((m: any) => (
-          <li key={m._id}>
-            {m.text || m.content}
-            {m.file && (
-              <a href={m.file} target="_blank" rel="noopener noreferrer">
-                {m.filename || "Fichier"}
-              </a>
-            )}
-          </li>
+          <MessageItem key={m._id} message={m} />
         ))}
       </ul>
       <form onSubmit={handleSubmit} className={styles["form"]}>

--- a/client-web/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.module.scss
+++ b/client-web/src/pages/WorkspaceDetailPage/WorkspaceDetailPage.module.scss
@@ -132,3 +132,14 @@
   margin-top: 0.5rem;
 }
 
+.searchInput {
+  margin-bottom: 1rem;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  width: 100%;
+  max-width: 30rem;
+  background: var(--color-bg-input);
+  font-size: 1.4rem;
+}
+

--- a/client-web/src/pages/WorkspaceDetailPage/index.tsx
+++ b/client-web/src/pages/WorkspaceDetailPage/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useWorkspaceDetails } from "@hooks/useWorkspaceDetails";
 import styles from "./WorkspaceDetailPage.module.scss";
@@ -35,6 +35,7 @@ const WorkspaceDetailPage: React.FC = () => {
     fetchChannels,
     handleCreateChannel,
   } = useChannels(id || "");
+  const [search, setSearch] = useState("");
   const { permissions, setRole, loading: permLoading } = usePermissions(id || "");
 
   if (loading) {
@@ -198,12 +199,23 @@ const WorkspaceDetailPage: React.FC = () => {
       <div className={styles["sectionGrid"]}>
         <div className={styles["section"]}>
           <h2>Canaux</h2>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Rechercher..."
+            className={styles["searchInput"]}
+          />
           {channelsLoading ? (
             <Loader />
           ) : channelsError ? (
             <p className={styles["error"]}>{channelsError}</p>
           ) : (
-            <ChannelList channels={channels} onAccess={handleChannelAccess} />
+            <ChannelList
+              channels={channels}
+              filter={search}
+              onAccess={handleChannelAccess}
+            />
           )}
         </div>
         {isAdminOrOwner && (

--- a/client-web/src/pages/WorkspacePage/WorkspacePage.module.scss
+++ b/client-web/src/pages/WorkspacePage/WorkspacePage.module.scss
@@ -35,6 +35,17 @@
   }
 }
 
+.searchInput {
+  margin-bottom: 2rem;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  width: 100%;
+  max-width: 30rem;
+  background: var(--color-bg-input);
+  font-size: 1.4rem;
+}
+
 .modalOverlay {
   position: fixed;
   top: 0;

--- a/client-web/src/pages/WorkspacePage/index.tsx
+++ b/client-web/src/pages/WorkspacePage/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import WorkspaceCreateForm from "@components/Workspace/WorkspaceCreateForm";
 import WorkspaceList from "@components/Workspace/WorkspaceList";
 import Loader from "@components/Loader";
@@ -34,6 +34,7 @@ const WorkspacesPage: React.FC = () => {
     inviteSuccess,
     setInviteSuccess,
   } = useWorkspacePageLogic();
+  const [search, setSearch] = useState("");
 
   return (
     <section className={styles["workspaceSection"]}>
@@ -44,6 +45,13 @@ const WorkspacesPage: React.FC = () => {
       >
         Créer un workspace
       </button>
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Rechercher..."
+        className={styles["searchInput"]}
+      />
 
       {showModal && (
         <div className={styles["modalOverlay"]}>
@@ -169,6 +177,7 @@ const WorkspacesPage: React.FC = () => {
       ) : (
         <WorkspaceList
           workspaces={workspaces}
+          filter={search}
           user={user ?? undefined}
           onAccess={handleAccess}
           onInvite={handleInviteClick}


### PR DESCRIPTION
## Summary
- implement `MessageItem` component for full message view
- add notifications section on the dashboard
- support search/filter in workspace and channel lists
- enable file previews and auto-scroll in message page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d0ce5ef008324b90abbd4a41e8d46