### PR TITLE
Fix workspace join role

### DIFF
--- a/supchat-server/services/workspaceService.js
+++ b/supchat-server/services/workspaceService.js
@@ -142,7 +142,7 @@ const join = async (inviteCode, user) => {
     await Permission.create({
         userId: user.id,
         workspaceId: workspace._id,
-        role: 'member',
+        role: 'membre',
         permissions: {
             canPost: true,
             canDeleteMessages: false,


### PR DESCRIPTION
## Summary
- use the correct role string when joining a workspace

## Testing
- `grep -n "role: 'member'" -r supchat-server | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684d19bd08dc832487cc5a476025ba54