### PR TITLE
Fix invitation cleanup when joining workspace

### DIFF
--- a/supchat-server/services/workspaceService.js
+++ b/supchat-server/services/workspaceService.js
@@ -161,12 +161,15 @@ const join = async (inviteCode, user) => {
         },
     })
 
-    // Ajout dans members (évite doublons)
-    await Workspace.findByIdAndUpdate(workspace._id, {
-        $addToSet: { members: user.id },
-    })
+  // Ajout dans members (évite doublons) et suppression de l'invitation
+  await Workspace.findByIdAndUpdate(workspace._id, {
+    $addToSet: { members: user.id },
+    $pull: { invitations: user.email },
+  })
 
-    return workspace
+  const updatedWorkspace = await Workspace.findById(workspace._id)
+  await updatedWorkspace.save()
+  return updatedWorkspace
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- update `workspaceService.join` to remove invitation after adding member

## Testing
- No tests run due to repository restrictions

------
https://chatgpt.com/codex/tasks/task_e_684d1c35248c8324948afd74c6d19b66