### PR TITLE
Restrict channel listing to workspace members

### DIFF
--- a/supchat-server/controllers/channelController.js
+++ b/supchat-server/controllers/channelController.js
@@ -39,9 +39,20 @@ exports.getChannels = async (req, res) => {
       return res.status(400).json({ message: "ID du workspace requis" });
     }
 
-    const channels = await channelService.findByWorkspace(workspaceId);
+    const channels = await channelService.findByWorkspace(
+      workspaceId,
+      req.user
+    );
     return res.status(200).json(channels);
   } catch (error) {
+    if (error.message === "WORKSPACE_NOT_FOUND") {
+      return res.status(404).json({ message: "Workspace non trouvé" });
+    }
+    if (error.message === "NOT_ALLOWED") {
+      return res
+        .status(403)
+        .json({ message: "Accès refusé. Droits insuffisants." });
+    }
     return res.status(500).json({ message: "Erreur serveur", error });
   }
 };

--- a/supchat-server/services/channelService.js
+++ b/supchat-server/services/channelService.js
@@ -53,7 +53,22 @@ const create = async ({ name, workspaceId, description, type }, user) => {
   return channel;
 };
 
-const findByWorkspace = (workspaceId) => {
+const findByWorkspace = async (workspaceId, user) => {
+  const workspace = await Workspace.findById(workspaceId);
+  if (!workspace) {
+    throw new Error("WORKSPACE_NOT_FOUND");
+  }
+
+  const isOwner = String(workspace.owner) === String(user.id);
+  const perm = await Permission.findOne({ userId: user.id, workspaceId });
+  const isMember = workspace.members?.some(
+    (m) => String(m._id || m) === String(user.id)
+  );
+
+  if (!isOwner && !perm && !isMember) {
+    throw new Error("NOT_ALLOWED");
+  }
+
   return Channel.find({ workspace: workspaceId });
 };
 


### PR DESCRIPTION
## Summary
- enforce channel list access control via `Permission` checks
- handle workspace not found and permission errors in controller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d1e446ca48324acea46b7a3ec5e91