### PR TITLE
Allow channel management via permission

### DIFF
--- a/supchat-server/services/channelService.js
+++ b/supchat-server/services/channelService.js
@@ -10,12 +10,9 @@ const isAdminOrOwner = async (userId, workspaceId) => {
   if (String(workspace.owner) === String(userId)) {
     return true;
   }
-  const perm = await Permission.findOne({
-    userId,
-    workspaceId,
-    role: "admin",
-  });
-  return !!perm;
+  const perm = await Permission.findOne({ userId, workspaceId });
+  if (!perm) return false;
+  return perm.role === "admin" || perm.permissions?.canManageChannels;
 };
 
 const isChannelAdmin = async (userId, channel) => {
@@ -31,7 +28,7 @@ const isChannelAdmin = async (userId, channel) => {
     workspaceId: workspace._id,
   });
   if (!perm) return false;
-  if (perm.role === "admin") return true;
+  if (perm.role === "admin" || perm.permissions?.canManageChannels) return true;
   const chanRole = perm.channelRoles?.find(
     (c) => String(c.channelId) === String(channel._id)
   );


### PR DESCRIPTION
## Summary
- broaden admin checks for channel creation/deletion

## Testing
- `npm test` *(fails: see note)*

------
https://chatgpt.com/codex/tasks/task_e_684d20658f0c8324b72eeea739bdb568