### PR TITLE
Implement reactions and file metadata

### DIFF
--- a/client-web/src/components/Message/MessageItem/index.tsx
+++ b/client-web/src/components/Message/MessageItem/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styles from "./MessageItem.module.scss";
+import ReactionBar from "../ReactionBar";
 
 interface MessageItemProps {
   message: any;
@@ -36,6 +37,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
           </a>
         )
       )}
+      <ReactionBar messageId={message._id} />
     </li>
   );
 };

--- a/client-web/src/components/Message/ReactionBar/ReactionBar.module.scss
+++ b/client-web/src/components/Message/ReactionBar/ReactionBar.module.scss
@@ -1,0 +1,10 @@
+.bar {
+  margin-top: 4px;
+}
+
+.btn {
+  margin-right: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}

--- a/client-web/src/components/Message/ReactionBar/index.tsx
+++ b/client-web/src/components/Message/ReactionBar/index.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useReactions } from "@hooks/useReactions";
+import styles from "./ReactionBar.module.scss";
+
+interface ReactionBarProps {
+  messageId: string;
+}
+
+const ReactionBar: React.FC<ReactionBarProps> = ({ messageId }) => {
+  const { reactions, react } = useReactions(messageId);
+
+  const grouped: Record<string, number> = {};
+  reactions.forEach((r: any) => {
+    grouped[r.emoji] = (grouped[r.emoji] || 0) + 1;
+  });
+
+  const handle = (emoji: string) => {
+    react(emoji);
+  };
+
+  return (
+    <div className={styles["bar"]}>
+      {Object.entries(grouped).map(([e, count]) => (
+        <button key={e} type="button" className={styles["btn"]} onClick={() => handle(e)}>
+          {e} {count}
+        </button>
+      ))}
+      <button type="button" className={styles["btn"]} onClick={() => handle("👍")}>+
+      </button>
+    </div>
+  );
+};
+
+export default ReactionBar;

--- a/client-web/src/hooks/useReactions.ts
+++ b/client-web/src/hooks/useReactions.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "@store/store";
+import {
+  fetchReactions,
+  sendReaction,
+  pushReaction,
+  removeReactionLocal,
+} from "@store/reactionsSlice";
+import { useSocket } from "@hooks/useSocket";
+
+export function useReactions(messageId: string) {
+  const dispatch = useDispatch<AppDispatch>();
+  const socket = useSocket();
+
+  const reactions = useSelector((state: RootState) =>
+    state.reactions.items.filter((r) => r.messageId === messageId)
+  );
+
+  const react = async (emoji: string) => {
+    await dispatch(sendReaction({ messageId, emoji }));
+  };
+
+  useEffect(() => {
+    dispatch(fetchReactions(messageId));
+  }, [dispatch, messageId]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const added = (r: any) => {
+      if (r.messageId === messageId) dispatch(pushReaction(r));
+    };
+    const removed = (r: any) => {
+      if (r.messageId === messageId) dispatch(removeReactionLocal(r._id));
+    };
+    socket.on("reactionAdded", added);
+    socket.on("reactionRemoved", removed);
+    return () => {
+      socket.off("reactionAdded", added);
+      socket.off("reactionRemoved", removed);
+    };
+  }, [socket, dispatch, messageId]);
+
+  return { reactions, react };
+}

--- a/client-web/src/services/reactionApi.ts
+++ b/client-web/src/services/reactionApi.ts
@@ -1,0 +1,23 @@
+import api, { fetchCsrfToken } from "@utils/axiosInstance";
+
+export interface ReactionPayload {
+  messageId: string;
+  emoji: string;
+}
+
+export async function getReactions(messageId: string) {
+  await fetchCsrfToken();
+  const { data } = await api.get(`/reactions/${messageId}`);
+  return data;
+}
+
+export async function addReaction(payload: ReactionPayload) {
+  await fetchCsrfToken();
+  const { data } = await api.post("/reactions", payload);
+  return data;
+}
+
+export async function removeReaction(id: string) {
+  await fetchCsrfToken();
+  await api.delete(`/reactions/${id}`);
+}

--- a/client-web/src/store/reactionsSlice.ts
+++ b/client-web/src/store/reactionsSlice.ts
@@ -1,0 +1,63 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  getReactions,
+  addReaction,
+  removeReaction,
+  ReactionPayload,
+} from "@services/reactionApi";
+
+export const fetchReactions = createAsyncThunk(
+  "reactions/fetch",
+  async (messageId: string) => {
+    return await getReactions(messageId);
+  }
+);
+
+export const sendReaction = createAsyncThunk(
+  "reactions/add",
+  async (payload: ReactionPayload) => {
+    return await addReaction(payload);
+  }
+);
+
+export const deleteReaction = createAsyncThunk(
+  "reactions/delete",
+  async (id: string) => {
+    await removeReaction(id);
+    return id;
+  }
+);
+
+const reactionsSlice = createSlice({
+  name: "reactions",
+  initialState: {
+    items: [] as any[],
+  },
+  reducers: {
+    pushReaction: (state, action) => {
+      state.items.push(action.payload);
+    },
+    removeReactionLocal: (state, action) => {
+      state.items = state.items.filter((r) => r._id !== action.payload);
+    },
+    clearReactions: (state) => {
+      state.items = [];
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchReactions.fulfilled, (state, action) => {
+        state.items = action.payload;
+      })
+      .addCase(sendReaction.fulfilled, (state, action) => {
+        state.items.push(action.payload);
+      })
+      .addCase(deleteReaction.fulfilled, (state, action) => {
+        state.items = state.items.filter((r) => r._id !== action.payload);
+      });
+  },
+});
+
+export const { pushReaction, removeReactionLocal, clearReactions } =
+  reactionsSlice.actions;
+export default reactionsSlice.reducer;

--- a/client-web/src/store/store.ts
+++ b/client-web/src/store/store.ts
@@ -7,6 +7,7 @@ import channelsReducer from "@store/channelsSlice";
 import messagesReducer from "@store/messagesSlice";
 import notificationsReducer from "@store/notificationsSlice";
 import preferencesReducer from "@store/preferencesSlice";
+import reactionsReducer from "@store/reactionsSlice";
 
 export const store = configureStore({
   reducer: {
@@ -16,6 +17,7 @@ export const store = configureStore({
     messages: messagesReducer,
     notifications: notificationsReducer,
     preferences: preferencesReducer,
+    reactions: reactionsReducer,
   },
 });
 

--- a/supchat-server/controllers/messageController.js
+++ b/supchat-server/controllers/messageController.js
@@ -64,6 +64,18 @@ exports.sendMessage = async (req, res) => {
     }
 
     await message.save();
+    if (req.file) {
+      const FileMeta = require("../models/FileMeta");
+      const meta = new FileMeta({
+        filename: req.file.filename,
+        originalName: req.file.originalname,
+        mimetype: req.file.mimetype,
+        size: req.file.size,
+        channelId,
+        uploader: req.user.id,
+      });
+      await meta.save();
+    }
     const io = getIo();
     try {
       io.to(channelId).emit("newMessage", message);

--- a/supchat-server/controllers/reactionController.js
+++ b/supchat-server/controllers/reactionController.js
@@ -1,0 +1,58 @@
+const Reaction = require("../models/Reaction");
+const Message = require("../models/Message");
+const { getIo } = require("../socket");
+
+exports.addReaction = async (req, res) => {
+  try {
+    const { messageId, emoji } = req.body;
+    if (!messageId || !emoji) {
+      return res.status(400).json({ message: "messageId et emoji requis" });
+    }
+    const existing = await Reaction.findOne({ messageId, userId: req.user.id, emoji });
+    if (existing) {
+      return res.status(409).json({ message: "Deja react" });
+    }
+    const reaction = new Reaction({ messageId, userId: req.user.id, emoji });
+    await reaction.save();
+    const msg = await Message.findById(messageId);
+    if (msg) {
+      getIo().to(String(msg.channelId || msg.channel)).emit("reactionAdded", reaction);
+    }
+    return res.status(201).json(reaction);
+  } catch (error) {
+    res.status(500).json({ message: "Erreur serveur.", error });
+  }
+};
+
+exports.removeReaction = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const reaction = await Reaction.findById(id);
+    if (!reaction) {
+      return res.status(404).json({ message: "Reaction non trouv\u00e9e" });
+    }
+    if (String(reaction.userId) !== req.user.id) {
+      return res.status(403).json({ message: "Action non autorisee" });
+    }
+    await Reaction.findByIdAndDelete(id);
+    const msg = await Message.findById(reaction.messageId);
+    if (msg) {
+      getIo()
+        .to(String(msg.channelId || msg.channel))
+        .emit("reactionRemoved", { _id: id, messageId: reaction.messageId });
+    }
+    res.status(200).json({ message: "Reaction supprimee" });
+  } catch (error) {
+    res.status(500).json({ message: "Erreur serveur.", error });
+  }
+};
+
+exports.getReactionsByMessage = async (req, res) => {
+  try {
+    const { messageId } = req.params;
+    const reactions = await Reaction.find({ messageId });
+    res.status(200).json(reactions);
+  } catch (error) {
+    res.status(500).json({ message: "Erreur serveur.", error });
+  }
+};

--- a/supchat-server/models/Reaction.js
+++ b/supchat-server/models/Reaction.js
@@ -1,0 +1,12 @@
+const mongoose = require("mongoose");
+
+const ReactionSchema = new mongoose.Schema({
+  messageId: { type: mongoose.Schema.Types.ObjectId, ref: "Message", required: true },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+  emoji: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+ReactionSchema.index({ messageId: 1, userId: 1, emoji: 1 }, { unique: true });
+
+module.exports = mongoose.model("Reaction", ReactionSchema);

--- a/supchat-server/routes/index.js
+++ b/supchat-server/routes/index.js
@@ -10,6 +10,7 @@ const notificationRoutes = require('./notification.Routes')
 const searchRoutes = require('./search.Routes')
 const userRoutes = require('./user.Routes')
 const integrationRoutes = require('./integration.Routes')
+const reactionRoutes = require('./reaction.Routes')
 
 router.use('/auth', authRoutes)
 router.use('/workspaces', workspaceRoutes)
@@ -20,5 +21,6 @@ router.use('/notifications', notificationRoutes)
 router.use('/search', searchRoutes)
 router.use('/user', userRoutes)
 router.use('/integrations', integrationRoutes)
+router.use('/reactions', reactionRoutes)
 
 module.exports = router

--- a/supchat-server/routes/reaction.Routes.js
+++ b/supchat-server/routes/reaction.Routes.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const { authMiddleware } = require("../middlewares/authMiddleware");
+const {
+  addReaction,
+  removeReaction,
+  getReactionsByMessage,
+} = require("../controllers/reactionController");
+
+const router = express.Router();
+
+router.post("/", authMiddleware, addReaction);
+router.get("/:messageId", authMiddleware, getReactionsByMessage);
+router.delete("/:id", authMiddleware, removeReaction);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- support adding reactions to messages with new routes and controller
- track uploaded file metadata in `sendMessage`
- expose reaction API client-side and new Redux slice
- add `ReactionBar` component to display message reactions
- wire reactions into message list and socket events

## Testing
- `npm test` *(fails: project has no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684d24b3a980832497fa4e4158e876fc