### PR TITLE
feat: notify invited user for workspace

### DIFF
--- a/supchat-server/services/workspaceService.js
+++ b/supchat-server/services/workspaceService.js
@@ -125,7 +125,7 @@ const invite = async (workspaceId, email, user) => {
         workspace.invitations.push(email)
         await workspace.save()
     }
-    return workspace
+    return { workspace, invitedUser }
 }
 
 const join = async (inviteCode, user) => {


### PR DESCRIPTION
## Summary
- notify invited user via socket after sending workspace invite email
- return invited user from workspaceService.invite

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dadd3522483249168fc559374a805