### PR TITLE
Extend notifications populate query

### DIFF
--- a/supchat-server/controllers/notificationController.js
+++ b/supchat-server/controllers/notificationController.js
@@ -4,7 +4,9 @@ exports.getNotifications = async (req, res) => {
   try {
     const notifs = await Notification.find({ userId: req.user.id })
       .sort({ createdAt: -1 })
-      .populate("messageId");
+      .populate("messageId")
+      .populate("workspaceId", "name")
+      .populate("channelId", "name");
     res.status(200).json(notifs);
   } catch (error) {
     res.status(500).json({ message: "Erreur serveur", error });


### PR DESCRIPTION
## Summary
- return populated workspace and channel names when fetching notifications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684daf80dbf48324a3d055be006919c0