### PR TITLE
Implement channel deletion in web UI

### DIFF
--- a/client-web/src/components/Channel/ChannelEditModal/ChannelEditModal.module.scss
+++ b/client-web/src/components/Channel/ChannelEditModal/ChannelEditModal.module.scss
@@ -57,3 +57,19 @@
 .submitButton {
   align-self: center;
 }
+
+.deleteButton {
+  align-self: center;
+  background: none;
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
+  padding: 0.6rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--color-error);
+    color: #fff;
+  }
+}

--- a/client-web/src/components/Channel/ChannelEditModal/index.tsx
+++ b/client-web/src/components/Channel/ChannelEditModal/index.tsx
@@ -4,6 +4,7 @@ import styles from "./ChannelEditModal.module.scss";
 interface ChannelEditModalProps {
   channel: any;
   onUpdate: (data: { name: string; description: string }) => Promise<void>;
+  onDelete?: () => Promise<void>;
   onClose: () => void;
   loading?: boolean;
   error?: string | null;
@@ -12,6 +13,7 @@ interface ChannelEditModalProps {
 const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
   channel,
   onUpdate,
+  onDelete,
   onClose,
   loading,
   error,
@@ -64,6 +66,20 @@ const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
           <button type="submit" className={styles["submitButton"]} disabled={loading}>
             {loading ? "Enregistrement..." : "Enregistrer"}
           </button>
+          {onDelete && (
+            <button
+              type="button"
+              className={styles["deleteButton"]}
+              onClick={() => {
+                if (window.confirm("Supprimer ce canal ?")) {
+                  onDelete();
+                }
+              }}
+              disabled={loading}
+            >
+              Supprimer
+            </button>
+          )}
         </form>
       </div>
     </div>

--- a/client-web/src/hooks/useChannelDetails.ts
+++ b/client-web/src/hooks/useChannelDetails.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import { getChannelById, updateChannel } from "@services/channelApi";
+import { removeChannel } from "@store/channelsSlice";
+import type { AppDispatch } from "@store/store";
 
 export function useChannelDetails(channelId: string) {
+  const dispatch = useDispatch<AppDispatch>();
   const [channel, setChannel] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -36,6 +40,23 @@ export function useChannelDetails(channelId: string) {
     }
   };
 
+  const handleDelete = async () => {
+    if (!channel) return;
+    setUpdating(true);
+    setUpdateError(null);
+    try {
+      await dispatch(
+        removeChannel({ channelId, workspaceId: channel.workspace })
+      ).unwrap();
+      return channel.workspace;
+    } catch (err: any) {
+      setUpdateError(err.message || "Erreur lors de la suppression");
+      throw err;
+    } finally {
+      setUpdating(false);
+    }
+  };
+
   useEffect(() => {
     fetchDetails();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -47,6 +68,7 @@ export function useChannelDetails(channelId: string) {
     error,
     fetchDetails,
     handleUpdate,
+    handleDelete,
     updating,
     updateError,
   };

--- a/client-web/src/pages/MessagesPage/index.tsx
+++ b/client-web/src/pages/MessagesPage/index.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { useState, useEffect, useRef } from "react";
 import { useMessages } from "@hooks/useMessages";
 import { useChannelDetails } from "@hooks/useChannelDetails";
@@ -16,9 +16,11 @@ function MessagesPage() {
     channel,
     loading: channelLoading,
     handleUpdate,
+    handleDelete,
     updating,
     updateError,
   } = useChannelDetails(channelId);
+  const navigate = useNavigate();
   const user = useSelector((state: RootState) => state.auth.user);
   const [showEdit, setShowEdit] = useState(false);
   const [text, setText] = useState("");
@@ -83,6 +85,12 @@ function MessagesPage() {
         <ChannelEditModal
           channel={channel}
           onUpdate={handleUpdate}
+          onDelete={async () => {
+            const ws = await handleDelete();
+            if (ws) {
+              navigate(`/workspaces/${ws}`);
+            }
+          }}
           onClose={() => setShowEdit(false)}
           loading={updating}
           error={updateError}


### PR DESCRIPTION
## Summary
- add delete support in ChannelEditModal and styling
- enhance useChannelDetails with removeChannel dispatch
- update MessagesPage to handle channel deletion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dbe22577c83249f8e2d9ca16bac95