### PR TITLE
Add message editing and hashtags

### DIFF
--- a/client-web/src/components/Message/MessageItem/MessageItem.module.scss
+++ b/client-web/src/components/Message/MessageItem/MessageItem.module.scss
@@ -32,3 +32,14 @@
   color: var(--color-link);
   word-break: break-all;
 }
+
+.actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.editForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}

--- a/client-web/src/components/Message/MessageItem/index.tsx
+++ b/client-web/src/components/Message/MessageItem/index.tsx
@@ -1,13 +1,32 @@
-import React from "react";
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import type { RootState } from "@store/store";
 import styles from "./MessageItem.module.scss";
 import ReactionBar from "../ReactionBar";
 
 interface MessageItemProps {
   message: any;
+  onEdit?: (text: string, file?: File | null) => void;
+  onDelete?: () => void;
 }
 
-const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
+const MessageItem: React.FC<MessageItemProps> = ({ message, onEdit, onDelete }) => {
+  const user = useSelector((state: RootState) => state.auth.user);
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(message.text || "");
+  const [file, setFile] = useState<File | null>(null);
+
   const isImage = message.mimetype && message.mimetype.startsWith("image/");
+  const canEdit =
+    user &&
+    (user.role === "admin" || String(user.email) === message.userId?.email);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onEdit?.(text, file);
+    setEditing(false);
+    setFile(null);
+  };
   return (
     <li className={styles["item"]}>
       <div className={styles["meta"]}>
@@ -18,26 +37,53 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
           {new Date(message.createdAt).toLocaleString()}
         </span>
       </div>
-      {message.text && <p className={styles["text"]}>{message.text}</p>}
-      {isImage ? (
-        <img
-          src={message.file}
-          alt={message.filename || ""}
-          className={styles["image"]}
-        />
+      {editing ? (
+        <form onSubmit={handleSubmit} className={styles["editForm"]}>
+          <input
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <input
+            type="file"
+            onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+          />
+          <button type="submit">Enregistrer</button>
+          <button type="button" onClick={() => setEditing(false)}>
+            Annuler
+          </button>
+        </form>
       ) : (
-        message.file && (
-          <a
-            href={message.file}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles["file"]}
-          >
-            {message.filename || "Fichier"}
-          </a>
-        )
+        <>
+          {message.text && <p className={styles["text"]}>{message.text}</p>}
+          {isImage ? (
+            <img
+              src={message.file}
+              alt={message.filename || ""}
+              className={styles["image"]}
+            />
+          ) : (
+            message.file && (
+              <a
+                href={message.file}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles["file"]}
+              >
+                {message.filename || "Fichier"}
+              </a>
+            )
+          )}
+          <ReactionBar messageId={message._id} />
+          {canEdit && (
+            <div className={styles["actions"]}>
+              <button type="button" onClick={() => setEditing(true)}>
+                Éditer
+              </button>
+              <button type="button" onClick={() => onDelete?.()}>Supprimer</button>
+            </div>
+          )}
+        </>
       )}
-      <ReactionBar messageId={message._id} />
     </li>
   );
 };

--- a/client-web/src/pages/MessagesPage/index.tsx
+++ b/client-web/src/pages/MessagesPage/index.tsx
@@ -11,7 +11,7 @@ import ChannelEditModal from "@components/Channel/ChannelEditModal";
 function MessagesPage() {
   const [params] = useSearchParams();
   const channelId = params.get("channel") || "";
-  const { messages, loading, send } = useMessages(channelId);
+  const { messages, loading, send, update: updateMsg, remove } = useMessages(channelId);
   const {
     channel,
     loading: channelLoading,
@@ -59,7 +59,14 @@ function MessagesPage() {
       </div>
       <ul ref={listRef} className={styles["list"]}>
         {messages.map((m: any) => (
-          <MessageItem key={m._id} message={m} />
+          <MessageItem
+            key={m._id}
+            message={m}
+            onEdit={(text: string, file?: File | null) =>
+              updateMsg(m._id, text, file)
+            }
+            onDelete={() => remove(m._id)}
+          />
         ))}
         {!loading && messages.length === 0 && (
           <li className={styles["empty"]}>Aucun message pour le moment.</li>

--- a/client-web/src/services/messageApi.ts
+++ b/client-web/src/services/messageApi.ts
@@ -35,3 +35,35 @@ export async function sendMessage(formData: MessageFormData) {
     );
   }
 }
+
+export async function updateMessage(
+  id: string,
+  payload: { text: string; file?: File | null }
+) {
+  try {
+    await fetchCsrfToken();
+    const dataToSend = new FormData();
+    dataToSend.append("text", payload.text);
+    if (payload.file) dataToSend.append("file", payload.file);
+    const { data } = await api.put(`/messages/${id}`, dataToSend, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message || err.message || "Erreur lors de la mise à jour"
+    );
+  }
+}
+
+export async function removeMessage(id: string) {
+  try {
+    await fetchCsrfToken();
+    const { data } = await api.delete(`/messages/${id}`);
+    return data;
+  } catch (err: any) {
+    throw new Error(
+      err?.response?.data?.message || err.message || "Erreur lors de la suppression"
+    );
+  }
+}

--- a/supchat-server/models/Message.js
+++ b/supchat-server/models/Message.js
@@ -12,8 +12,9 @@ const MessageSchema = new mongoose.Schema({
   filename: String,
   mimetype: String,
   size: Number,
+  hashtags: [String],
 });
 
-MessageSchema.index({ text: "text", content: "text" });
+MessageSchema.index({ text: "text", content: "text", hashtags: 1 });
 
 module.exports = mongoose.model("Message", MessageSchema);

--- a/supchat-server/routes/message.Routes.js
+++ b/supchat-server/routes/message.Routes.js
@@ -5,6 +5,7 @@ const {
   sendMessage,
   getMessagesByChannel,
   getMessageById,
+  updateMessage,
   deleteMessage,
 } = require("../controllers/messageController");
 const { authMiddleware } = require("../middlewares/authMiddleware");
@@ -24,6 +25,7 @@ const router = express.Router();
 router.post("/", authMiddleware, upload.single("file"), sendMessage);
 router.get("/channel/:channelId", authMiddleware, getMessagesByChannel);
 router.get("/:id", authMiddleware, getMessageById);
+router.put("/:id", authMiddleware, upload.single("file"), updateMessage);
 router.delete("/:id", authMiddleware, deleteMessage);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- store hashtags in `Message` schema and parse them when sending
- add message update API and extend delete API
- emit `messageEdited` and `messageDeleted` socket events
- support editing and deleting messages in the client
- update message-related Redux slice, hook and UI

## Testing
- No automated tests run due to repository restrictions

------
https://chatgpt.com/codex/tasks/task_e_684dc14ede3483249596982c95fee4b3