### PR TITLE
Add comprehensive API test suite

### DIFF
--- a/supchat-server/package.json
+++ b/supchat-server/package.json
@@ -5,7 +5,11 @@
   "scripts": {
     "start": "node swagger.js && nodemon ./src/app.js",
     "build": "tsc && node dist/app.js",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "test:unit": "jest --testPathPattern=unit",
+    "test:integration": "jest --testPathPattern=integration",
+    "test:e2e": "jest --testPathPattern=e2e",
+    "test:coverage": "jest --coverage --coverageThreshold=80"
   },
   "description": "Supchat-server",
   "author": "",

--- a/supchat-server/tests/factories/channelFactory.js
+++ b/supchat-server/tests/factories/channelFactory.js
@@ -1,0 +1,14 @@
+const { faker } = require("@faker-js/faker");
+
+const channelFactory = (overrides = {}) => ({
+  name: faker.word.words({ count: { min: 1, max: 3 } }),
+  description: faker.lorem.sentence(),
+  workspace: overrides.workspace,
+  type: "public",
+  members: [],
+  invitations: [],
+  messages: [],
+  ...overrides,
+});
+
+module.exports = { channelFactory };

--- a/supchat-server/tests/factories/index.js
+++ b/supchat-server/tests/factories/index.js
@@ -1,0 +1,11 @@
+const { userFactory } = require("./userFactory");
+const { workspaceFactory } = require("./workspaceFactory");
+const { channelFactory } = require("./channelFactory");
+const { messageFactory } = require("./messageFactory");
+
+module.exports = {
+  userFactory,
+  workspaceFactory,
+  channelFactory,
+  messageFactory,
+};

--- a/supchat-server/tests/factories/messageFactory.js
+++ b/supchat-server/tests/factories/messageFactory.js
@@ -1,0 +1,11 @@
+const { faker } = require("@faker-js/faker");
+
+const messageFactory = (overrides = {}) => ({
+  text: faker.lorem.sentence(),
+  channel: overrides.channel,
+  userId: overrides.userId,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+module.exports = { messageFactory };

--- a/supchat-server/tests/factories/userFactory.js
+++ b/supchat-server/tests/factories/userFactory.js
@@ -1,0 +1,11 @@
+const { faker } = require("@faker-js/faker");
+
+const userFactory = (overrides = {}) => ({
+  name: faker.person.fullName(),
+  email: faker.internet.email(),
+  password: "pass",
+  role: "membre",
+  ...overrides,
+});
+
+module.exports = { userFactory };

--- a/supchat-server/tests/factories/workspaceFactory.js
+++ b/supchat-server/tests/factories/workspaceFactory.js
@@ -1,0 +1,14 @@
+const { faker } = require("@faker-js/faker");
+
+const workspaceFactory = (overrides = {}) => ({
+  name: faker.company.name(),
+  description: faker.company.catchPhrase(),
+  isPublic: true,
+  owner: overrides.ownerId,
+  members: [],
+  channels: [],
+  invitations: [],
+  ...overrides,
+});
+
+module.exports = { workspaceFactory };

--- a/supchat-server/tests/routes/auth.test.js
+++ b/supchat-server/tests/routes/auth.test.js
@@ -1,0 +1,37 @@
+const request = require("supertest");
+const { app } = require("../../src/app");
+const User = require("../../models/User");
+const { userFactory } = require("../factories/userFactory");
+
+describe("POST /auth/login", () => {
+  it("login with email and password", async () => {
+    const user = await User.create(userFactory({ password: "pass" }));
+
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: user.email, password: "pass" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("token");
+  });
+
+  it("fails with wrong credentials", async () => {
+    const user = await User.create(userFactory({ password: "pass" }));
+
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: user.email, password: "wrong" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("login with provider token", async () => {
+    const user = await User.create(userFactory({ googleId: "gid-1" }));
+
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ provider: "google", token: "fake" });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/supchat-server/tests/routes/channels.test.js
+++ b/supchat-server/tests/routes/channels.test.js
@@ -1,0 +1,78 @@
+const request = require("supertest");
+const { app } = require("../../src/app");
+const Channel = require("../../models/Channel");
+const Workspace = require("../../models/Workspace");
+const User = require("../../models/User");
+const Message = require("../../models/Message");
+const { channelFactory } = require("../factories/channelFactory");
+const { workspaceFactory } = require("../factories/workspaceFactory");
+const { userFactory } = require("../factories/userFactory");
+const { messageFactory } = require("../factories/messageFactory");
+
+describe("Channel routes", () => {
+  let workspace;
+  beforeEach(async () => {
+    workspace = await Workspace.create(
+      workspaceFactory({ owner: global.adminId, members: [global.adminId] })
+    );
+  });
+
+  describe("POST /channels", () => {
+    it("creates channel", async () => {
+      const res = await request(app)
+        .post("/api/channels")
+        .set("Authorization", `Bearer ${global.tokens.admin}`)
+        .send({ name: "my channel", workspaceId: workspace._id, type: "public" });
+
+      expect(res.status).toBe(201);
+      expect(res.body.name).toBe("my channel");
+    });
+
+    it("denies guest", async () => {
+      const res = await request(app)
+        .post("/api/channels")
+        .set("Authorization", `Bearer ${global.tokens.guest}`)
+        .send({ name: "guest", workspaceId: workspace._id, type: "public" });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /channels/:id/messages", () => {
+    it("returns channel messages", async () => {
+      const channel = await Channel.create(
+        channelFactory({ workspace: workspace._id })
+      );
+      const msg = await Message.create(
+        messageFactory({ channel: channel._id, userId: global.adminId })
+      );
+
+      const res = await request(app)
+        .get(`/api/channels/${channel._id}/messages`)
+        .set("Authorization", `Bearer ${global.tokens.admin}`);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("POST /channels/:id/messages", () => {
+    it("posts message and emits socket", async () => {
+      const channel = await Channel.create(
+        channelFactory({ workspace: workspace._id })
+      );
+      const emitSpy = jest.spyOn(global.socketClient, "emit");
+
+      const res = await request(app)
+        .post(`/api/channels/${channel._id}/messages`)
+        .set("Authorization", `Bearer ${global.tokens.admin}`)
+        .send({ text: "hello" });
+
+      expect(res.status).toBe(201);
+      expect(emitSpy).toHaveBeenCalledWith(
+        channel._id.toString(),
+        "new_message",
+        expect.objectContaining({ text: "hello" })
+      );
+    });
+  });
+});

--- a/supchat-server/tests/routes/workspaces.test.js
+++ b/supchat-server/tests/routes/workspaces.test.js
@@ -1,0 +1,63 @@
+const request = require("supertest");
+const { app } = require("../../src/app");
+const Workspace = require("../../models/Workspace");
+const User = require("../../models/User");
+const { workspaceFactory } = require("../factories/workspaceFactory");
+const { userFactory } = require("../factories/userFactory");
+
+describe("POST /workspaces", () => {
+  it("creates workspace when admin", async () => {
+    const res = await request(app)
+      .post("/api/workspaces")
+      .set("Authorization", `Bearer ${global.tokens.admin}`)
+      .send({ name: "Test Workspace" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe("Test Workspace");
+  });
+
+  it("forbids member", async () => {
+    const res = await request(app)
+      .post("/api/workspaces")
+      .set("Authorization", `Bearer ${global.tokens.member}`)
+      .send({ name: "Fail" });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /workspaces/:id/invite", () => {
+  it("invite user and send WebSocket notification", async () => {
+    const workspace = await Workspace.create(
+      workspaceFactory({ owner: global.adminId })
+    );
+    const invitedUser = await User.create(userFactory());
+    const emitSpy = jest.spyOn(global.socketClient, "emit");
+
+    const res = await request(app)
+      .post(`/api/workspaces/${workspace._id}/invite`)
+      .set("Authorization", `Bearer ${global.tokens.admin}`)
+      .send({ email: invitedUser.email });
+
+    expect(res.status).toBe(200);
+    expect(emitSpy).toHaveBeenCalledWith(
+      `user_${invitedUser._id}`,
+      "notification",
+      expect.objectContaining({ type: "workspace_invite" })
+    );
+  });
+
+  it("returns 403 for non admin", async () => {
+    const workspace = await Workspace.create(
+      workspaceFactory({ owner: global.adminId })
+    );
+    const user = await User.create(userFactory());
+
+    const res = await request(app)
+      .post(`/api/workspaces/${workspace._id}/invite`)
+      .set("Authorization", `Bearer ${global.tokens.member}`)
+      .send({ email: user.email });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/supchat-server/tests/security/cors.test.js
+++ b/supchat-server/tests/security/cors.test.js
@@ -1,0 +1,9 @@
+const request = require("supertest");
+const { app } = require("../../src/app");
+
+describe("Security headers", () => {
+  it("sets CORS headers", async () => {
+    const res = await request(app).options("/api/workspaces");
+    expect(res.headers["access-control-allow-origin"]).toBeDefined();
+  });
+});

--- a/supchat-server/tests/security/permissions.test.js
+++ b/supchat-server/tests/security/permissions.test.js
@@ -1,0 +1,38 @@
+const request = require("supertest");
+const { app } = require("../../src/app");
+const Channel = require("../../models/Channel");
+const { channelFactory } = require("../factories/channelFactory");
+const Workspace = require("../../models/Workspace");
+const { workspaceFactory } = require("../factories/workspaceFactory");
+
+describe("Private channel access", () => {
+  it("allows member of channel", async () => {
+    const workspace = await Workspace.create(
+      workspaceFactory({ owner: global.adminId, members: [global.adminId] })
+    );
+    const channel = await Channel.create(
+      channelFactory({ workspace: workspace._id, type: "private", members: [global.adminId] })
+    );
+
+    const res = await request(app)
+      .get(`/api/channels/${channel._id}`)
+      .set("Authorization", `Bearer ${global.tokens.admin}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("denies non member", async () => {
+    const workspace = await Workspace.create(
+      workspaceFactory({ owner: global.adminId, members: [global.adminId] })
+    );
+    const channel = await Channel.create(
+      channelFactory({ workspace: workspace._id, type: "private", members: [] })
+    );
+
+    const res = await request(app)
+      .get(`/api/channels/${channel._id}`)
+      .set("Authorization", `Bearer ${global.tokens.member}`);
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/supchat-server/tests/security/rateLimit.test.js
+++ b/supchat-server/tests/security/rateLimit.test.js
@@ -1,0 +1,31 @@
+const request = require("supertest");
+const { app } = require("../../src/app");
+const Channel = require("../../models/Channel");
+const { channelFactory } = require("../factories/channelFactory");
+const Workspace = require("../../models/Workspace");
+const { workspaceFactory } = require("../factories/workspaceFactory");
+
+describe("Message rate limiting", () => {
+  it("limits frequent posting", async () => {
+    const workspace = await Workspace.create(
+      workspaceFactory({ owner: global.adminId, members: [global.adminId] })
+    );
+    const channel = await Channel.create(
+      channelFactory({ workspace: workspace._id, members: [global.adminId] })
+    );
+
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post(`/api/channels/${channel._id}/messages`)
+        .set("Authorization", `Bearer ${global.tokens.admin}`)
+        .send({ text: "spam" });
+    }
+
+    const res = await request(app)
+      .post(`/api/channels/${channel._id}/messages`)
+      .set("Authorization", `Bearer ${global.tokens.admin}`)
+      .send({ text: "spam" });
+
+    expect([200, 429]).toContain(res.status);
+  });
+});

--- a/supchat-server/tests/security/validation.test.js
+++ b/supchat-server/tests/security/validation.test.js
@@ -1,0 +1,13 @@
+const request = require("supertest");
+const { app } = require("../../src/app");
+
+describe("Validation middleware", () => {
+  it("rejects invalid payload", async () => {
+    const res = await request(app)
+      .post("/api/workspaces")
+      .set("Authorization", `Bearer ${global.tokens.admin}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/supchat-server/tests/setup.js
+++ b/supchat-server/tests/setup.js
@@ -1,5 +1,18 @@
 const mongoose = require("mongoose");
 const { MongoMemoryServer } = require("mongodb-memory-server");
+const ioClient = require("socket.io-client");
+const jwt = require("jsonwebtoken");
+const { faker } = require("@faker-js/faker");
+
+const User = require("../models/User");
+const Workspace = require("../models/Workspace");
+const Channel = require("../models/Channel");
+const Message = require("../models/Message");
+
+const { userFactory } = require("./factories/userFactory");
+const { workspaceFactory } = require("./factories/workspaceFactory");
+const { channelFactory } = require("./factories/channelFactory");
+const { messageFactory } = require("./factories/messageFactory");
 
 let mongoServer;
 
@@ -7,10 +20,43 @@ beforeAll(async () => {
   mongoServer = await MongoMemoryServer.create();
   const uri = mongoServer.getUri();
   await mongoose.connect(uri);
+
+  // Seed users
+  const admin = await User.create(userFactory({ role: "admin", password: "pass" }));
+  const member = await User.create(userFactory({ role: "membre", password: "pass" }));
+  const guest = await User.create(userFactory({ role: "invité", password: "pass" }));
+
+  global.adminId = admin._id;
+
+  // Seed workspace and channel
+  const workspace = await Workspace.create(
+    workspaceFactory({ owner: admin._id, members: [admin._id] })
+  );
+  const channel = await Channel.create(
+    channelFactory({ workspace: workspace._id, members: [admin._id] })
+  );
+  await Message.create(
+    messageFactory({ channel: channel._id, userId: admin._id })
+  );
+
+  workspace.channels.push(channel._id);
+  await workspace.save();
+
+  // JWT tokens
+  const secret = "testsecret";
+  global.tokens = {
+    admin: jwt.sign({ id: admin._id, role: "admin" }, secret),
+    member: jwt.sign({ id: member._id, role: "membre" }, secret),
+    guest: jwt.sign({ id: guest._id, role: "invité" }, secret),
+  };
+
+  // Socket.io client for tests
+  global.socketClient = ioClient("http://localhost");
 });
 
 afterAll(async () => {
   await mongoose.connection.dropDatabase();
   await mongoose.disconnect();
   await mongoServer.stop();
+  global.socketClient.close();
 });

--- a/supchat-server/tests/sockets/websocket.test.js
+++ b/supchat-server/tests/sockets/websocket.test.js
@@ -1,0 +1,38 @@
+const io = require("socket.io-client");
+const { server } = require("../../src/app");
+
+describe("WebSocket interactions", () => {
+  let client;
+
+  beforeEach((done) => {
+    client = io("http://localhost", { forceNew: true });
+    client.on("connect", done);
+  });
+
+  afterEach(() => {
+    if (client.connected) client.disconnect();
+  });
+
+  it("connects to personal room", (done) => {
+    client.emit("subscribeNotifications", "123");
+    client.on("joined", () => {
+      done();
+    });
+  });
+
+  it("receives invitation notification", (done) => {
+    client.on("notification", (payload) => {
+      try {
+        expect(payload.type).toBe("workspace_invite");
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+
+    server.emit("notification", {
+      room: "user_123",
+      type: "workspace_invite",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- set up test suite with MongoMemoryServer and socket mocks
- add factories for users, workspaces, channels and messages
- create route tests for auth, workspaces and channels
- create websocket and security tests
- extend npm scripts for test types

## Testing
- `No tests run due to AGENTS guidelines`

------
https://chatgpt.com/codex/tasks/task_e_684dcb5943e483248d656005e64f05aa