### PR TITLE
Add socket.io-client dev dependency

### DIFF
--- a/supchat-server/package-lock.json
+++ b/supchat-server/package-lock.json
@@ -43,6 +43,7 @@
         "swagger-jsdoc": "^6.2.8"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.2.0",
         "@types/bcrypt": "^5.0.2",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
@@ -53,6 +54,7 @@
         "mongodb-memory-server": "^10.1.3",
         "nodemon": "^3.1.9",
         "react-email": "^4.0.16",
+        "socket.io-client": "^4.7.5",
         "supertest": "^7.0.0",
         "swagger-autogen": "^2.23.7",
         "swagger-ui-express": "^5.0.1",

--- a/supchat-server/package.json
+++ b/supchat-server/package.json
@@ -49,6 +49,7 @@
     "socket.io": "^4.7.5"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.2.0",
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
@@ -59,6 +60,7 @@
     "mongodb-memory-server": "^10.1.3",
     "nodemon": "^3.1.9",
     "react-email": "^4.0.16",
+    "socket.io-client": "^4.7.5",
     "supertest": "^7.0.0",
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.1",

--- a/supchat-server/tests/setup.js
+++ b/supchat-server/tests/setup.js
@@ -43,11 +43,11 @@ beforeAll(async () => {
   await workspace.save();
 
   // JWT tokens
-  const secret = "testsecret";
+  process.env.JWT_SECRET = "testsecret";
   global.tokens = {
-    admin: jwt.sign({ id: admin._id, role: "admin" }, secret),
-    member: jwt.sign({ id: member._id, role: "membre" }, secret),
-    guest: jwt.sign({ id: guest._id, role: "invité" }, secret),
+    admin: jwt.sign({ id: admin._id, role: "admin" }, process.env.JWT_SECRET),
+    member: jwt.sign({ id: member._id, role: "membre" }, process.env.JWT_SECRET),
+    guest: jwt.sign({ id: guest._id, role: "invité" }, process.env.JWT_SECRET),
   };
 
   // Socket.io client for tests


### PR DESCRIPTION
## Summary
- add `socket.io-client` and `@faker-js/faker` to server dev deps
- configure JWT secret in test setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dcf01a8c08324a11de30878ca0889