### PR TITLE
Fix test DB connection conflict

### DIFF
--- a/supchat-server/src/app.js
+++ b/supchat-server/src/app.js
@@ -107,13 +107,17 @@ const mongoUri =
         MONGO_DB || 'supchat'
     }?authSource=${MONGO_AUTH_SOURCE || 'admin'}`
 
-mongoose
-    .connect(mongoUri)
-    .then(() => console.log('MongoDB connected'))
-    .catch((err) => {
-        console.error('MongoDB connection error:', err)
-        process.exit(1)
-    })
+if (process.env.NODE_ENV !== 'test') {
+    mongoose
+        .connect(mongoUri)
+        .then(() => console.log('MongoDB connected'))
+        .catch((err) => {
+            console.error('MongoDB connection error:', err)
+            process.exit(1)
+        })
+} else {
+    console.log('MongoDB connection skipped in test environment')
+}
 
 // ==== ROUTES ==== //
 const apiRoutes = require('../routes/index')

--- a/supchat-server/tests/setup.js
+++ b/supchat-server/tests/setup.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+process.env.NODE_ENV = "test";
 const { MongoMemoryServer } = require("mongodb-memory-server");
 const ioClient = require("socket.io-client");
 const jwt = require("jsonwebtoken");


### PR DESCRIPTION
## Summary
- avoid connecting to MongoDB when `NODE_ENV` is `test`
- explicitly set `NODE_ENV` to `test` during Jest setup

## Testing
- `No tests run due to policy`

------
https://chatgpt.com/codex/tasks/task_e_684dd21637e883248dc6bc4d0cb5e7dd