### PR TITLE
Fix CSRF middleware for tests

### DIFF
--- a/supchat-server/jest.config.js
+++ b/supchat-server/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   testEnvironment: "node",
+  setupFiles: ["./tests/setupEnv.js"],
   setupFilesAfterEnv: ["./tests/setup.js"],
 };

--- a/supchat-server/tests/setupEnv.js
+++ b/supchat-server/tests/setupEnv.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test'


### PR DESCRIPTION
## Summary
- skip CSRF protection when running in test environment

## Testing
- `No tests run due to policy`

------
https://chatgpt.com/codex/tasks/task_e_684dd21637e883248dc6bc4d0cb5e7dd