### PR TITLE
Add token in login response

### DIFF
--- a/supchat-server/controllers/authController.js
+++ b/supchat-server/controllers/authController.js
@@ -95,9 +95,10 @@ exports.login = async (req, res) => {
 
         const { _id, name, email: user_email, role, createdAt } = user
 
-        return res
-            .status(200)
-            .json({ user: { _id, name, email: user_email, role, createdAt } })
+        return res.status(200).json({
+            token: accessToken,
+            user: { _id, name, email: user_email, role, createdAt },
+        })
     } catch (error) {
         console.error('Erreur login:', error)
         res.status(500).json({


### PR DESCRIPTION
## Summary
- add `token` field to `login` response

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684dda76cd8883249d0032badfeb7ef0