### PR TITLE
Remove hashtags from message index

### DIFF
--- a/supchat-server/models/Message.js
+++ b/supchat-server/models/Message.js
@@ -15,6 +15,6 @@ const MessageSchema = new mongoose.Schema({
   hashtags: [String],
 });
 
-MessageSchema.index({ text: "text", content: "text", hashtags: 1 });
+MessageSchema.index({ text: "text", content: "text" });
 
 module.exports = mongoose.model("Message", MessageSchema);


### PR DESCRIPTION
## Summary
- update the Message model so the text index only includes `text` and `content`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ddafe59008324a4011f7a7f4f4349