### PR TITLE
Fix server startup env check

### DIFF
--- a/supchat-server/src/app.js
+++ b/supchat-server/src/app.js
@@ -143,16 +143,12 @@ app.use((err, req, res, next) => {
 })
 
 // ==== START ==== //
-if (process.env.NODE_ENV !== 'test') {
-    server.listen(port, () => {
-        console.log(`Server running on http://localhost:${port}`)
-        console.log(
-            `Swagger docs available at http://localhost:${port}/api-docs/swagger-ui.html`
-        )
-    })
-} else {
-    console.log('Server listen skipped in test environment')
-}
+server.listen(port, () => {
+    console.log(`Server listening on port ${port}`)
+    console.log(
+        `Swagger docs available at http://localhost:${port}/api-docs/swagger-ui.html`
+    )
+})
 
 // Export for controllers (needed for generateCsrfToken in authController)
 module.exports = {


### PR DESCRIPTION
## Summary
- always start server so HTTP listen works in test environment
- log chosen port for easier debugging

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_684ddb93d4a0832498979bbacbd20d02