### PR TITLE
Fix permission role typo in test

### DIFF
--- a/supchat-server/tests/channel.permissions.test.js
+++ b/supchat-server/tests/channel.permissions.test.js
@@ -33,7 +33,7 @@ describe("Vérification des permissions sur les canaux", () => {
     await Permission.create({
       userId: member._id,
       workspaceId: workspace._id,
-      role: "member",
+      role: "membre",
       permissions: { canManageChannels: false },
     });
   });


### PR DESCRIPTION
## Summary
- change permission role from `member` to `membre` in channel permission tests

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_684ddcc9e5f883249a6e865f75a457de