### PR TITLE
Add reusable MessageInput component

### DIFF
--- a/client-web/src/components/MessageInput/MessageInput.module.scss
+++ b/client-web/src/components/MessageInput/MessageInput.module.scss
@@ -1,0 +1,5 @@
+.form {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/client-web/src/components/MessageInput/index.tsx
+++ b/client-web/src/components/MessageInput/index.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import styles from "./MessageInput.module.scss";
+
+interface MessageInputProps {
+  onSend: (text: string, file?: File | null) => Promise<void> | void;
+  loading?: boolean;
+}
+
+const MessageInput: React.FC<MessageInputProps> = ({ onSend, loading }) => {
+  const [text, setText] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim() && !file) return;
+    await onSend(text.trim(), file);
+    setText("");
+    setFile(null);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={styles["form"]}>
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        disabled={loading}
+      />
+      <input
+        type="file"
+        onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+        disabled={loading}
+      />
+      <button type="submit" disabled={loading}>
+        Envoyer
+      </button>
+    </form>
+  );
+};
+
+export default MessageInput;

--- a/client-web/src/pages/MessagesPage/MessagesPage.module.scss
+++ b/client-web/src/pages/MessagesPage/MessagesPage.module.scss
@@ -12,11 +12,6 @@
   overflow-y: auto;
 }
 
-.form {
-  display: flex;
-  gap: 0.5rem;
-  margin-top: 1rem;
-}
 
 .header {
   display: flex;

--- a/client-web/src/pages/MessagesPage/index.tsx
+++ b/client-web/src/pages/MessagesPage/index.tsx
@@ -7,6 +7,7 @@ import type { RootState } from "@store/store";
 import styles from "./MessagesPage.module.scss";
 import MessageItem from "@components/Message/MessageItem";
 import ChannelEditModal from "@components/Channel/ChannelEditModal";
+import MessageInput from "@components/MessageInput";
 
 function MessagesPage() {
   const [params] = useSearchParams();
@@ -23,17 +24,7 @@ function MessagesPage() {
   const navigate = useNavigate();
   const user = useSelector((state: RootState) => state.auth.user);
   const [showEdit, setShowEdit] = useState(false);
-  const [text, setText] = useState("");
-  const [file, setFile] = useState<File | null>(null);
   const listRef = useRef<HTMLUListElement | null>(null);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!text.trim() && !file) return;
-    await send(text.trim(), file);
-    setText("");
-    setFile(null);
-  };
 
   useEffect(() => {
     if (listRef.current) {
@@ -72,22 +63,7 @@ function MessagesPage() {
           <li className={styles["empty"]}>Aucun message pour le moment.</li>
         )}
       </ul>
-      <form onSubmit={handleSubmit} className={styles["form"]}>
-        <input
-          type="text"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          disabled={loading}
-        />
-        <input
-          type="file"
-          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
-          disabled={loading}
-        />
-        <button type="submit" disabled={loading}>
-          Envoyer
-        </button>
-      </form>
+      <MessageInput onSend={send} loading={loading} />
       {showEdit && channel && (
         <ChannelEditModal
           channel={channel}


### PR DESCRIPTION
## Summary
- create `MessageInput` component under `src/components`
- move form styles to a dedicated module
- use `MessageInput` in `MessagesPage`
- remove obsolete form styles

## Testing
- No tests run due to project restrictions

------
https://chatgpt.com/codex/tasks/task_e_684de48142908324b3860995896ad2c3