### PR TITLE
Add missing components and useAuth hook

### DIFF
--- a/client-web/src/components/AuthForm/index.tsx
+++ b/client-web/src/components/AuthForm/index.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from "react";
+import { useAuth } from "@hooks/useAuth";
+
+const AuthForm: React.FC = () => {
+  const { login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await login(email, password);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label htmlFor="email">Email</label>
+      <input
+        id="email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <label htmlFor="password">Mot de passe</label>
+      <input
+        id="password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Connexion</button>
+    </form>
+  );
+};
+
+export default AuthForm;

--- a/client-web/src/components/ChannelSidebar/index.tsx
+++ b/client-web/src/components/ChannelSidebar/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ChannelList, { Channel } from "@components/Channel/ChannelList";
+
+interface ChannelSidebarProps {
+  channels: Channel[];
+  onSelect?: (channel: Channel) => void;
+}
+
+const ChannelSidebar: React.FC<ChannelSidebarProps> = ({ channels, onSelect }) => {
+  return (
+    <aside>
+      <ChannelList channels={channels} onAccess={onSelect} />
+    </aside>
+  );
+};
+
+export default ChannelSidebar;

--- a/client-web/src/components/MessageInput/index.tsx
+++ b/client-web/src/components/MessageInput/index.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+
+interface MessageInputProps {
+  onSend: (text: string, file: File | null) => void;
+}
+
+const MessageInput: React.FC<MessageInputProps> = ({ onSend }) => {
+  const [text, setText] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSend(text, file);
+    setText("");
+    setFile(null);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <input
+        type="file"
+        onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+      />
+      <button type="submit">Envoyer</button>
+    </form>
+  );
+};
+
+export default MessageInput;

--- a/client-web/src/components/NotificationBell/index.tsx
+++ b/client-web/src/components/NotificationBell/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { useNotifications } from "@hooks/useNotifications";
+
+const NotificationBell: React.FC = () => {
+  const { unread } = useNotifications();
+  return <button aria-label="notifications">{unread}</button>;
+};
+
+export default NotificationBell;

--- a/client-web/src/hooks/useAuth.ts
+++ b/client-web/src/hooks/useAuth.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+export function useAuth() {
+  const [loading, setLoading] = useState(false);
+
+  const login = async (email: string, password: string) => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (data.token) {
+        localStorage.setItem("token", data.token);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem("token");
+  };
+
+  return { login, logout, loading };
+}


### PR DESCRIPTION
## Summary
- implement `AuthForm` with local login
- create `ChannelSidebar` wrapper around `ChannelList`
- add `MessageInput` component for sending text or files
- implement simple `NotificationBell`
- add `useAuth` hook for login/logout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ddf9d25048324b9a0062c84b74a27