### PR TITLE
Fix MSW patterns for join request tests

### DIFF
--- a/web/src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx
+++ b/web/src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx
@@ -99,7 +99,8 @@ beforeEach(() => {
       return HttpResponse.json([]);
     }),
     // Handler pour les permissions du workspace (évite l’erreur permissions.find)
-    http.get("/api/permissions", ({ request }) => {
+    // Utilise un motif avec wildcard pour matcher l'URL complète peu importe le préfixe
+    http.get("*/permissions", ({ request }) => {
       const url = new URL(request.url);
       if (url.searchParams.get("workspaceId") === "ws1") {
         return HttpResponse.json([
@@ -122,7 +123,7 @@ beforeEach(() => {
       return HttpResponse.json([]);
     }),
     // Handler pour les membres du workspace
-    http.get("/api/workspaces/ws1/members", () => {
+    http.get("*/workspaces/ws1/members", () => {
       return HttpResponse.json([
         { _id: "user1", username: "Alice", role: "admin" },
         { _id: "user2", username: "Bob", role: "member" },


### PR DESCRIPTION
## Summary
- fix MSW handlers in `ChannelsPage.joinRequests.test.tsx` to match API URLs with wildcards

## Testing
- `npx vitest run src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685f1423e7c4832497755b5a85894ef3