### PR TITLE
Add UI for channel join requests

### DIFF
--- a/web/src/components/messaging/Channel/ChannelJoinRequestsList.tsx
+++ b/web/src/components/messaging/Channel/ChannelJoinRequestsList.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from "react";
+import type { ChannelJoinRequest } from "@ts_types/channel";
+
+interface ChannelJoinRequestsListProps {
+  requests: ChannelJoinRequest[];
+  loading?: boolean;
+  error?: string | null;
+  onAccept: (requestId: string) => void;
+  onDecline: (requestId: string) => void;
+  feedback?: string | null;
+}
+
+const ChannelJoinRequestsList: React.FC<ChannelJoinRequestsListProps> = ({
+  requests,
+  loading,
+  error,
+  onAccept,
+  onDecline,
+  feedback,
+}) => {
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [localFeedback, setLocalFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (feedback) {
+      setLocalFeedback(feedback);
+      const t = setTimeout(() => setLocalFeedback(null), 3500);
+      return () => clearTimeout(t);
+    }
+  }, [feedback]);
+
+  if (loading) return <div aria-busy="true">Chargement des demandes...</div>;
+  if (error)
+    return (
+      <div role="alert" style={{ color: "red" }}>
+        {error}
+      </div>
+    );
+  if (!requests || requests.length === 0) return null;
+
+  return (
+    <div
+      style={{ marginBottom: 16 }}
+      aria-label="Demandes d’adhésion en attente"
+      role="region"
+    >
+      <h4 style={{ marginBottom: 8 }}>Demandes d’adhésion en attente</h4>
+      {localFeedback && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            background: "#e6ffe6",
+            color: "#217a36",
+            border: "1px solid #b2e5b2",
+            borderRadius: 4,
+            padding: 8,
+            marginBottom: 8,
+            fontWeight: 500,
+          }}
+        >
+          {localFeedback}
+        </div>
+      )}
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        {requests.map((req) => (
+          <li
+            key={req._id}
+            style={{ marginBottom: 8, display: "flex", alignItems: "center" }}
+          >
+            <span style={{ flex: 1 }}>
+              Demande de <b>{req.userId}</b>
+            </span>
+            <button
+              onClick={async () => {
+                setActionLoading(req._id);
+                await onAccept(req._id);
+                setActionLoading(null);
+              }}
+              disabled={!!actionLoading || loading}
+              aria-disabled={!!actionLoading || loading}
+              style={{ marginRight: 8 }}
+            >
+              {actionLoading === req._id && loading ? "..." : "Accepter"}
+            </button>
+            <button
+              onClick={async () => {
+                setActionLoading(req._id);
+                await onDecline(req._id);
+                setActionLoading(null);
+              }}
+              disabled={!!actionLoading || loading}
+              aria-disabled={!!actionLoading || loading}
+              style={{ color: "red" }}
+            >
+              {actionLoading === req._id && loading ? "..." : "Refuser"}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ChannelJoinRequestsList;

--- a/web/src/pages/channels/ChannelsPage/index.tsx
+++ b/web/src/pages/channels/ChannelsPage/index.tsx
@@ -13,6 +13,7 @@ import ChannelInviteModal from "@components/messaging/Channel/ChannelInviteModal
 import Loader from "@components/core/ui/Loader";
 import MessageItem from "@components/messaging/Message/MessageItem";
 import ChannelInvitationsList from "@components/messaging/Channel/ChannelInvitationsList";
+import ChannelJoinRequestsList from "@components/messaging/Channel/ChannelJoinRequestsList";
 import FeedbackToast from "@components/core/ui/FeedbackToast";
 import type { Channel, ChannelType } from "@ts_types/channel";
 import type { WorkspaceMember } from "@ts_types/workspace";
@@ -408,6 +409,21 @@ const ChannelsPage: React.FC<ChannelsPageProps> = () => {
     );
   };
 
+  // Affichage des demandes d'adhésion en attente
+  const renderJoinRequests = () => {
+    if (!logic.joinRequests || logic.joinRequests.length === 0) return null;
+    return (
+      <ChannelJoinRequestsList
+        requests={logic.joinRequests}
+        loading={logic.joinRequestsLoading}
+        error={logic.joinRequestsError}
+        onAccept={logic.handleAcceptJoinRequest}
+        onDecline={logic.handleDeclineJoinRequest}
+        feedback={logic.joinRequestFeedback}
+      />
+    );
+  };
+
   return (
     <div className={styles["unifiedChannelPage"]}>
       <FeedbackToast feedbacks={logic.feedbacks} />
@@ -465,9 +481,10 @@ const ChannelsPage: React.FC<ChannelsPageProps> = () => {
                 );
                 const joinRequest = logic.joinRequests?.find(
                   (req) =>
-                    req.channelId === channel._id &&
-                    req.userId === user?._id &&
-                    req.status === "pending"
+                    // Optional chaining guards against undefined entries
+                    req?.channelId === channel._id &&
+                    req?.userId === user?._id &&
+                    req?.status === "pending"
                 );
                 return (
                   <div
@@ -505,7 +522,7 @@ const ChannelsPage: React.FC<ChannelsPageProps> = () => {
                       )}
                     </button>
                     {/* Bouton Rejoindre pour channels publics si non membre */}
-                    {isPublic && !isMember && logic.canInvite && (
+                    {isPublic && !isMember && (
                       <>
                         <button
                           className={styles["joinChannelBtn"]}
@@ -549,6 +566,7 @@ const ChannelsPage: React.FC<ChannelsPageProps> = () => {
       {/* Contenu principal */}
       <main className={styles["mainContent"]}>
         {renderInvitations()}
+        {renderJoinRequests()}
         {renderMainContent()}
       </main>
       {/* Panel droit (membres/paramètres/rôles) */}

--- a/web/src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx
+++ b/web/src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx
@@ -99,7 +99,8 @@ beforeEach(() => {
       return HttpResponse.json([]);
     }),
     // Handler pour les permissions du workspace (évite l’erreur permissions.find)
-    http.get("/api/permissions", ({ request }) => {
+    // Utilise un motif avec wildcard pour matcher l'URL complète peu importe le préfixe
+    http.get("*/permissions", ({ request }) => {
       const url = new URL(request.url);
       if (url.searchParams.get("workspaceId") === "ws1") {
         return HttpResponse.json([
@@ -122,7 +123,7 @@ beforeEach(() => {
       return HttpResponse.json([]);
     }),
     // Handler pour les membres du workspace
-    http.get("/api/workspaces/ws1/members", () => {
+    http.get("*/workspaces/ws1/members", () => {
       return HttpResponse.json([
         { _id: "user1", username: "Alice", role: "admin" },
         { _id: "user2", username: "Bob", role: "member" },


### PR DESCRIPTION
## Summary
- create `ChannelJoinRequestsList` component for pending join requests
- render join requests in `ChannelsPage`
- show join button for public channels regardless of permission
- guard join request lookup against undefined entries

## Testing
- `npx vitest run src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685f1423e7c4832497755b5a85894ef3