### PR TITLE
Fix join request permissions

### DIFF
--- a/web/src/hooks/useChannelsPageLogic.ts
+++ b/web/src/hooks/useChannelsPageLogic.ts
@@ -308,9 +308,8 @@ export function useChannelsPageLogic({
   };
 
   // Helpers permissions métier (basés sur channelRoles et user)
-  const currentUserRole = channelRoles.find(
-    (r) => r.userId === user?._id
-  )?.role;
+  const currentUserRole =
+    channelRoles.find((r) => r.userId === user?._id)?.role || userChannelRole;
   const isAdmin = currentUserRole === 'admin';
   const isMember = currentUserRole === 'membre';
   const isInvite = currentUserRole === 'invité';


### PR DESCRIPTION
## Summary
- ensure admin privileges fallback to user role while channel roles load

## Testing
- `npm test -- --run src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2996d8fc8324bcb24108465b8b26