### PR TITLE
Unify ChannelRole union

### DIFF
--- a/web/src/hooks/useChannelsPageLogic.ts
+++ b/web/src/hooks/useChannelsPageLogic.ts
@@ -312,7 +312,7 @@ export function useChannelsPageLogic({
     (r) => r.userId === user?._id
   )?.role;
   const isAdmin = currentUserRole === 'admin';
-  const isMember = currentUserRole === 'membre';
+  const isMember = currentUserRole === 'member';
   const isInvite = currentUserRole === 'invité';
 
   const canInvite = isAdmin || isMember;
@@ -466,7 +466,7 @@ export function useChannelsPageLogic({
         updateChannelMemberRole({
           channelId: activeChannelId!,
           userId,
-          role: 'membre',
+          role: 'member',
         })
       ).unwrap();
       setRoleFeedback('Administrateur rétrogradé membre.');

--- a/web/src/types/channel/role.ts
+++ b/web/src/types/channel/role.ts
@@ -1,6 +1,8 @@
 // src/types/channel/role.ts
 
-export type ChannelRole = 'admin' | 'membre' | 'invité';
+// Rôle d'un utilisateur au sein d'un canal
+// Harmonisé avec utils/channelPermissions.ts
+export type ChannelRole = 'admin' | 'member' | 'guest' | 'invité';
 
 export interface ChannelMemberRole {
   userId: string;

--- a/web/src/utils/channelPermissions.ts
+++ b/web/src/utils/channelPermissions.ts
@@ -1,6 +1,8 @@
 // Types et utilitaires pour la gestion des rôles et permissions des canaux
 
-export type ChannelRole = 'admin' | 'member' | 'guest' | 'invité';
+// Réutilisation du type métier défini dans src/types/channel
+import type { ChannelRole } from '@ts_types/channel';
+export type { ChannelRole };
 
 export interface ChannelPermissions {
   // Permissions de lecture


### PR DESCRIPTION
## Summary
- import `ChannelRole` in `channelPermissions` from types and re-export it
- define a single `ChannelRole` union including `admin`, `member`, `guest`, and `invité`
- adjust `useChannelsPageLogic` to use `member` string when demoting members and checking current role

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm test --silent` in api *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f316399288324b6fdb144a85e549a