### PR TITLE
Ensure join request success messages

### DIFF
--- a/web/src/hooks/useChannelsPageLogic.ts
+++ b/web/src/hooks/useChannelsPageLogic.ts
@@ -493,7 +493,7 @@ export function useChannelsPageLogic({
     setJoinRequestTarget(channelId);
     try {
       await dispatch(sendChannelJoinRequest({ channelId })).unwrap();
-      setJoinRequestFeedback('Demande d’adhésion envoyée.');
+      setJoinRequestFeedback('Demande envoyée.');
     } catch (err) {
       setJoinRequestFeedback(
         (err as Error).message || 'Erreur lors de la demande d’adhésion'


### PR DESCRIPTION
## Summary
- update success message when sending join request

## Testing
- `npx vitest run src/tests/pages/ChannelsPage/ChannelsPage.joinRequests.test.tsx` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685f338092c0832498ee137aa10743b8