### PR TITLE
Add renderWithProviders test utility

### DIFF
--- a/web/src/tests/test-utils.tsx
+++ b/web/src/tests/test-utils.tsx
@@ -83,6 +83,29 @@ export const TestProvider = ({
   </Provider>
 );
 
+function renderWithProviders(
+  ui: ReactElement,
+  {
+    route = "/",
+    storeOverride,
+    ...renderOptions
+  }: { route?: string; storeOverride?: typeof store } & RenderOptions = {}
+) {
+  const usedStore = storeOverride || store;
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <Provider store={usedStore}>
+        <QueryClientProvider client={queryClient}>
+          <MockSocketProvider>
+            <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+          </MockSocketProvider>
+        </QueryClientProvider>
+      </Provider>
+    ),
+    ...renderOptions,
+  });
+}
+
 function render(
   ui: ReactElement,
   {
@@ -119,4 +142,4 @@ function render(
 }
 
 export * from "@testing-library/react";
-export { render };
+export { render, renderWithProviders };


### PR DESCRIPTION
## Summary
- provide a `renderWithProviders` helper for tests that wraps components with all required providers
- export `renderWithProviders` alongside existing helpers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f47f7e85c83249ae4b17c90554f89