### PR TITLE
Update ChannelsPage tests to use render helper

### DIFF
--- a/web/src/tests/pages/ChannelsPage/ChannelsPage.permissions.test.tsx
+++ b/web/src/tests/pages/ChannelsPage/ChannelsPage.permissions.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithProviders } from "@tests/test-utils";
+import { render } from "@tests/test-utils";
 import ChannelsPage from "@pages/channels/ChannelsPage";
 import { screen } from "@testing-library/react";
 
@@ -7,7 +7,7 @@ import { screen } from "@testing-library/react";
 describe("ChannelsPage - UI conditionnelle selon permissions", () => {
   test("N’affiche pas les boutons d’action pour un utilisateur sans droits", async () => {
     // Simule un utilisateur sans droits (ex: viewer)
-    renderWithProviders(<ChannelsPage />);
+    render(<ChannelsPage />);
     // Les boutons d’invitation, promotion, suppression ne doivent pas être présents
     expect(screen.queryByRole("button", { name: /inviter/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /promouvoir/i })).not.toBeInTheDocument();
@@ -16,7 +16,7 @@ describe("ChannelsPage - UI conditionnelle selon permissions", () => {
 
   test("Affiche les boutons d’action uniquement pour les admins/modérateurs", async () => {
     // Simule un utilisateur admin
-    renderWithProviders(<ChannelsPage />);
+    render(<ChannelsPage />);
     expect(await screen.findByRole("button", { name: /inviter/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /promouvoir/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /supprimer/i })).toBeInTheDocument();

--- a/web/src/tests/pages/ChannelsPage/ChannelsPage.roles.test.tsx
+++ b/web/src/tests/pages/ChannelsPage/ChannelsPage.roles.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithProviders } from "@tests/test-utils";
+import { render } from "@tests/test-utils";
 import { server } from "@tests/mocks/server";
 import { rest } from "msw";
 import ChannelsPage from "@pages/channels/ChannelsPage";
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe("ChannelsPage - Gestion des rôles (promotion/rétrogradation)", () => {
   test("Affiche les boutons Promouvoir/Rétrograder pour les admins et permet l’action", async () => {
-    renderWithProviders(<ChannelsPage />);
+    render(<ChannelsPage />);
     // Boutons présents
     expect(await screen.findByRole("button", { name: /promouvoir/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /rétrograder/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update `ChannelsPage.permissions` and `ChannelsPage.roles` tests to use the `render` helper

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f498fb81c8324a75d95e1eb797a29