### PR TITLE
Add channel roles fixture and update tests

### DIFF
--- a/web/src/tests/fixtures/channelRoles.ts
+++ b/web/src/tests/fixtures/channelRoles.ts
@@ -1,0 +1,24 @@
+import { users } from './users';
+import { channels } from './channels';
+import type { ChannelMemberRole } from '@ts_types/channel';
+
+export const roles: ChannelMemberRole[] = [
+  {
+    userId: users[0]._id,
+    channelId: channels[0]._id,
+    role: 'admin',
+    updatedAt: '2024-06-01T12:00:00.000Z',
+  },
+  {
+    userId: users[1]._id,
+    channelId: channels[0]._id,
+    role: 'member',
+    updatedAt: '2024-06-01T12:05:00.000Z',
+  },
+  {
+    userId: users[2]._id,
+    channelId: channels[1]._id,
+    role: 'guest',
+    updatedAt: '2024-06-01T12:10:00.000Z',
+  },
+];

--- a/web/src/tests/pages/ChannelsPage/ChannelsPage.roles.test.tsx
+++ b/web/src/tests/pages/ChannelsPage/ChannelsPage.roles.test.tsx
@@ -6,7 +6,8 @@ import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
 // Mocks et fixtures
-import { channels, roles, users } from "@tests/fixtures/channels";
+import { channels, users } from "@tests/fixtures/channels";
+import { roles } from "@tests/fixtures/channelRoles";
 
 // MSW handlers pour gestion des rôles
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- add `channelRoles.ts` fixture exporting a `roles` array
- update ChannelsPage roles test to import new fixture

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4a584c248324ab46ee6844038f4c